### PR TITLE
[design] 알림 관련 반응형 대응 

### DIFF
--- a/src/components/Common/Layout/Notification/Notification.module.scss
+++ b/src/components/Common/Layout/Notification/Notification.module.scss
@@ -1,16 +1,40 @@
 .notification-popover {
-  width: 360px;
-  height: 648px;
   overflow-y: scroll;
   padding: 30px 20px;
-  top: -40px;
-  left: 90px;
-  z-index: 9999;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 999;
+  border-radius: 0;
+
+  @media (min-width: 768px) {
+    width: 360px;
+    height: 648px;
+    top: -40px;
+    left: 90px;
+    border-radius: 10px;
+  }
+
+  .notification-close {
+    position: absolute;
+    left: 20px;
+    top: 32px;
+
+    @media (min-width: 768px) {
+      display: none;
+    }
+  }
 
   .setting-icon {
     position: absolute;
     right: 20px;
-    top: 20px;
+    top: 27px;
+
+    @media (min-width: 48rem) {
+      top: 20px;
+    }
   }
 
   h2 {

--- a/src/components/Common/Layout/Notification/NotificationItem/NotificationItem.module.scss
+++ b/src/components/Common/Layout/Notification/NotificationItem/NotificationItem.module.scss
@@ -1,8 +1,12 @@
 .notification-item {
-  @include flex-arrange(flex-start, center);
-  gap: 6px;
+  @include flex-arrange(space-between, center);
+  gap: 12px;
   margin-bottom: 12px;
   line-height: 1.5em;
+
+  @media (min-width: 768px) {
+    gap: 6px;
+  }
 
   &:last-child {
     margin-bottom: 0;
@@ -13,6 +17,7 @@
   }
 
   p {
+    width: 100%;
     span {
       padding-left: 5px;
       color: $gray-01;

--- a/src/components/Common/Layout/Notification/NotificationModal/NotificationModal.module.scss
+++ b/src/components/Common/Layout/Notification/NotificationModal/NotificationModal.module.scss
@@ -2,15 +2,15 @@
   transform: translate(-27.2vw, -11.6vh);
 
   .notification-modal-wrapper {
-    margin-top: 30px;
+    margin-top: 40px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 20px;
+    gap: 25px;
   }
 
   .notification-modal-item {
-    width: 30%;
+    width: 100%;
     @include flex-arrange(space-between, center);
 
     h3 {

--- a/src/components/Common/Layout/Notification/NotificationModal/NotificationModal.module.scss
+++ b/src/components/Common/Layout/Notification/NotificationModal/NotificationModal.module.scss
@@ -1,12 +1,28 @@
 .notification-modal {
-  transform: translate(-27.2vw, -11.6vh);
+  text-align: center;
+
+  @media (min-width: 768px) {
+    transform: translate(-27.2vw, -11.6vh);
+  }
 
   .notification-modal-wrapper {
     margin-top: 40px;
-    display: flex;
+    width: 100%;
+    height: 100%;
+    @include flex-arrange(space-between, center);
     flex-direction: column;
-    align-items: center;
-    gap: 25px;
+
+    .notification-modal-container {
+      @include flex-arrange(flex-start, center);
+      flex-direction: column;
+      gap: 25px;
+      width: 100%;
+
+      @media (min-width: 768px) {
+        width: 50%;
+        margin: 0 auto 30px;
+      }
+    }
   }
 
   .notification-modal-item {

--- a/src/components/Common/Layout/Notification/NotificationModal/index.tsx
+++ b/src/components/Common/Layout/Notification/NotificationModal/index.tsx
@@ -26,17 +26,20 @@ export default function NotificationModal({
       className={cn('notification-modal')}
     >
       <div className={cn('notification-modal-wrapper')}>
-        <div className={cn('notification-modal-item')}>
-          <h3>댓글</h3>
-          <ToggleButton />
-        </div>
-        <div className={cn('notification-modal-item')}>
-          <h3>이모지</h3>
-          <ToggleButton />
-        </div>
-        <div className={cn('notification-modal-item')}>
-          <h3>팔로우</h3>
-          <ToggleButton />
+        {/* 모달 내 style 설정 때문에 임시로 감쌀 div 하나 추가. 추후 개선되면 삭제 예정 */}
+        <div className={cn('notification-modal-container')}>
+          <div className={cn('notification-modal-item')}>
+            <h3>댓글</h3>
+            <ToggleButton />
+          </div>
+          <div className={cn('notification-modal-item')}>
+            <h3>이모지</h3>
+            <ToggleButton />
+          </div>
+          <div className={cn('notification-modal-item')}>
+            <h3>팔로우</h3>
+            <ToggleButton />
+          </div>
         </div>
         <DefaultButton
           onClick={handleButtonClick}

--- a/src/components/Common/Layout/Notification/index.tsx
+++ b/src/components/Common/Layout/Notification/index.tsx
@@ -2,7 +2,7 @@ import styles from './Notification.module.scss';
 import classNames from 'classnames/bind';
 import PopOver from '@/components/Common/PopOverBox';
 import NotificationItem from './NotificationItem';
-import { SettingIcon } from '../../IconCollection';
+import { BackIcon, SettingIcon } from '../../IconCollection';
 import { useState } from 'react';
 import NotificationModal from './NotificationModal';
 
@@ -75,6 +75,12 @@ export default function Notification({ onClose }: PopOverProps) {
 
   return (
     <PopOver onClose={onClose} className={cn('notification-popover')}>
+      <BackIcon
+        className={cn('notification-close')}
+        width="18"
+        height="18"
+        onClick={onClose}
+      />
       <h2>알림</h2>
       <SettingIcon
         className={cn('setting-icon')}

--- a/src/components/Common/PopOverBox/PopOver.module.scss
+++ b/src/components/Common/PopOverBox/PopOver.module.scss
@@ -1,5 +1,4 @@
 .popOver-container {
-  max-width: 360px;
   margin: 0;
   padding: 10px 0;
   position: absolute;
@@ -10,5 +9,6 @@
 
   @media (min-width: 768px) {
     bottom: -64px;
+    max-width: 360px;
   }
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -4,6 +4,7 @@
   box-sizing: border-box;
   padding: 0;
   margin: 0;
+  font-family: 'Pretendard', Helvetica;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
## 📃 관련 이슈
#6
- 

## 💬 무슨 이유로 코드를 변경했는지
- 알림 관련 반응형 대응

## ❗ 어떤 위험이나 장애가 발견되었는지
- 일단... 모달 관련은 윤성님 createPotal 이 완료된 후에 한번 더 봐야 할 것 같습니다. 부모 영역 내에 한정되는 문제는 transform으로 임시대체 했습니다. 
- 이건 이 PR만의 문제는 아닌데, 배포시 SCSS가 컴파일되는 과정에서 뭔가 문제가 있는 것 같습니다. (내일 설명드릴게요)
- PopOver나 모달이 페이지로 되는 경우에도 createPotal을 사용해야 할 것 같습니다. 마찬가지로 윤성님 작업 끝나시면 제가 코드 추가하는 식으로 해볼게요 (아니면 다른 분이 작업해주시거나)
- 이유가, 제일 상단에 Layout으로 설정해놓은 header, sidebar이런것들에 일부가 가려지게 됩니다 (...) z-index: 9999 단순히 이런 문제로 처리할 수 있는게 아니라 보완이 필요할듯 합니다! (왜냐면 아무리 높게 설정해놔도 제일 상단에 있는 태그의 position: fixed 및 z-index를 우선으로 두기 때문에...) 때문에 createPotal로 넣어줄 제일 바깥쪽 빈 박스를 modal 이런 이름이 아니라 공통으로 지정할 필요가 있어보입니다.
- 모달에서 미리 설정되는 부분은 최소화하고 className을 받는다는 식으로 해보면 좋을것같은...? 생각이 듭니다 (여러모로 커스텀할 부분이 있어서... 미리 flex가 박혀있는 문제 때문에 불필요한 html 코드 네스팅이 됩니다.)

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  한꺼번에 작업하고 PR 올리는것보다 일단... 쪼개서 올려놓는게 좋을것같아서 올립니당 알림 관련 모바일 작업했습니다~ 

## ✅ 테스트 계획 또는 완료 사항
- 유연님 PR 머지되면 받아서 검색 페이지 관련 작업해볼 예정입니다! 

## 🖼️ 관련 스크린샷
![image](https://github.com/project-cosmo-sns/cosmos/assets/49646127/3a4a323b-5e54-4c73-a7b5-a157e2e416c1)
![image](https://github.com/project-cosmo-sns/cosmos/assets/49646127/15db379a-b38d-4545-b7c1-8129865dbc25)
![image](https://github.com/project-cosmo-sns/cosmos/assets/49646127/bd58b6fc-fa89-4f72-8e4e-d5b481756a8a)

