### PR TITLE
[chore] http locahost -> https변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ yarn-error.log*
 next-env.d.ts
 
 .github
+
+# mkcert
+.cert.pem
+.key.pem
+certificates

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node server.js",
     "build": "next build",
     "start": "next start",
     "prepare": "husky",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const https = require('https');
+const { parse } = require('url');
+const next = require('next');
+const fs = require('fs');
+const hostname = 'localhost';
+const port = 3000;
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+const httpsOptions = {
+  key: fs.readFileSync('./key.pem'),
+  cert: fs.readFileSync('./cert.pem'),
+};
+app.prepare().then(() => {
+  https
+    .createServer(httpsOptions, async (req, res) => {
+      try {
+        const parsedUrl = parse(req.url, true);
+        await handle(req, res, parsedUrl);
+      } catch (err) {
+        console.error('Error occurred handling', req.url, err);
+        res.statusCode = 500;
+        res.end('internal server error');
+      }
+    })
+    .listen(port, (err) => {
+      if (err) throw err;
+      console.log(`> Ready on https://${hostname}:${port}`);
+    });
+});

--- a/src/components/Common/LoginModal/LoginModal.module.scss
+++ b/src/components/Common/LoginModal/LoginModal.module.scss
@@ -2,9 +2,9 @@
   width: 100%;
   height: 100%;
   .login-wrapper {
-    @include flex-arrange(center, center);
+    @include flex-arrange;
     .header-wrapper {
-      @include flex-arrange(center, center);
+      @include flex-arrange;
       flex-direction: column;
       margin-top: 20px;
       gap: 10px;
@@ -12,8 +12,8 @@
         @include font-style(1.2rem, $black-03, 500);
         margin-bottom: 30px;
       }
-      .oauth-Wrapper {
-        @include flex-arrange(center, center);
+      .oauth-wrapper {
+        @include flex-arrange;
         flex-direction: column;
         gap: 8px;
       }

--- a/src/components/Common/LoginModal/index.tsx
+++ b/src/components/Common/LoginModal/index.tsx
@@ -21,7 +21,7 @@ export default function LoginModal({
       <div className={cn('header-wrapper')}>
         <LogoIcon width="105" height="30" />
         <h2>코스모스에 오신 것을 환영합니다!🙌</h2>
-        <div className={cn('oauth-Wrapper')}>
+        <div className={cn('oauth-wrapper')}>
           <LoginButton text="구글 로그인/ 회원가입" icon={<GoogleIcon />} />
           <LoginButton text="깃허브 로그인/ 회원가입" icon={<GitHubIcon />} />
         </div>

--- a/src/components/Profile/AuthForm/index.tsx
+++ b/src/components/Profile/AuthForm/index.tsx
@@ -25,7 +25,7 @@ export default function AuthForm({
 
   return (
     <Modal
-      title="회원인증"
+      title="스프린터 인증"
       modalVisible={modalVisible}
       toggleModal={toggleModal}
       cssModalSize={cn('auth-container')}
@@ -39,10 +39,10 @@ export default function AuthForm({
             type="text"
             placeholder="기수를 입력하세요. ex) 3"
             register={register('generation', {
-              required: '기수를 입력해주세요.',
+              required: '기수를 입력해 주세요.',
               pattern: {
                 value: generationRegex,
-                message: '숫자만 입력 해주세요.',
+                message: '숫자만 입력해 주세요.',
               },
             })}
           />

--- a/src/pages/test/index.page.tsx
+++ b/src/pages/test/index.page.tsx
@@ -1,5 +1,6 @@
 import { ContainerOptionType } from '@/@types/type';
 import ContentContainer from '@/components/Common/ContentContainer';
+import Modal from '@/components/Common/Layout/Modal';
 import LoginModal from '@/components/Common/LoginModal';
 import AuthForm from '@/components/Profile/AuthForm';
 import FollowList from '@/components/Profile/FollowList';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "server.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
<!--타이틀은 아래처럼 적어주세요
ex) [Feat] 로그인 기능 추가
    [Fix] 로그인이 안되는 문제 수정-->

## 📃 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #52 

## 💬 무슨 이유로 코드를 변경했는지
- 

## ❗ 어떤 위험이나 장애가 발견되었는지
- 

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
- server.js파일 만들고 포트는 그대로 3000번으로 넣었습니다.  
- 은주님이 보내주신 링크 따라서 mkcert -install 하고 인증서 받는 건  
mkcert -key-file key.pem -cert-file cert.pem localhost 127.0.0.1 ::1 이렇게 받았는데 그래도 안되면 
scripts에 "dev": "node server.js" 를 "dev":"next dev --experimental-https" 로 변경해보세요
그럼 인증서 어쩌고 하면서 알림창 뜨더라구요
https://vercel.com/guides/access-nextjs-localhost-https-certificate-self-signed
- 사실 저도 잘 모르겠습니다.... 막 해보다가 주강사님의 힘을 빌렸습니다. 

## ✅ 테스트 계획 또는 완료 사항
- 

## 🖼️ 관련 스크린샷
-
![스크린샷 2024-04-25 152551](https://github.com/project-cosmo-sns/cosmos/assets/133099388/315b0418-38c2-4d7d-8a52-12f071de67c3)

