### PR TITLE
[fix] 팝오버 UI 위치 틀어짐 수정

### DIFF
--- a/src/components/Common/AddContentPopOver/AddContentPopOver.module.scss
+++ b/src/components/Common/AddContentPopOver/AddContentPopOver.module.scss
@@ -1,11 +1,10 @@
 .add-popover {
-  bottom: 86px;
-  left: 70px;
+  left: 90px;
+  bottom: 78px;
 
   @media (min-width: 768px) {
     bottom: unset;
-    top: 282px;
-    left: 614px;
+    top: 200px;
   }
 }
 

--- a/src/components/Common/Layout/Layout.module.scss
+++ b/src/components/Common/Layout/Layout.module.scss
@@ -10,11 +10,6 @@
     flex-direction: column;
   }
 
-  .layout-sideBar {
-    position: relative;
-    height: auto;
-  }
-
   @media (min-width: 768px) {
     grid-template-columns: 1fr 76px 30px 614px 30px 1fr;
     display: grid;
@@ -28,8 +23,15 @@
     }
 
     .layout-sideBar {
+      position: relative;
       grid-column: 2;
       grid-row: 2;
+      height: 268px;
+
+      .popover-box {
+        position: fixed;
+        z-index: 10;
+      }
     }
   }
   @media (min-width: 1200px) {

--- a/src/components/Common/Layout/Layout.module.scss
+++ b/src/components/Common/Layout/Layout.module.scss
@@ -10,6 +10,11 @@
     flex-direction: column;
   }
 
+  .layout-sideBar {
+    position: relative;
+    height: auto;
+  }
+
   @media (min-width: 768px) {
     grid-template-columns: 1fr 76px 30px 614px 30px 1fr;
     display: grid;

--- a/src/components/Common/Layout/Notification/Notification.module.scss
+++ b/src/components/Common/Layout/Notification/Notification.module.scss
@@ -12,10 +12,11 @@
   backdrop-filter: blur(25px);
 
   @media (min-width: 768px) {
+    position: absolute;
     width: 360px;
     height: 648px;
-    top: 100px;
-    left: 605px;
+    top: -10px;
+    left: 90px;
     border-radius: 10px;
   }
 

--- a/src/components/Common/Layout/index.tsx
+++ b/src/components/Common/Layout/index.tsx
@@ -14,7 +14,7 @@ export default function Layout({ children }: layoutProps) {
     <div className={cn('layout-container')}>
       <div className={cn('layout-sideBar')}>
         <SideBar />
-        <div id="popover-root" />
+        <div id="popover-box" />
       </div>
       <div className={cn('layout-navigaionBar')}>
         <NavigaionBar />

--- a/src/components/Common/Layout/index.tsx
+++ b/src/components/Common/Layout/index.tsx
@@ -14,7 +14,7 @@ export default function Layout({ children }: layoutProps) {
     <div className={cn('layout-container')}>
       <div className={cn('layout-sideBar')}>
         <SideBar />
-        <div id="popover-box" />
+        <div id="popover-box" className={cn('popover-box')} />
       </div>
       <div className={cn('layout-navigaionBar')}>
         <NavigaionBar />

--- a/src/components/Common/PopOverBox/PopOver.module.scss
+++ b/src/components/Common/PopOverBox/PopOver.module.scss
@@ -8,6 +8,7 @@
   border: none;
 
   @media (min-width: 768px) {
+    position: absolute;
     max-width: 360px;
   }
 }

--- a/src/components/Common/PopOverBox/index.tsx
+++ b/src/components/Common/PopOverBox/index.tsx
@@ -24,7 +24,7 @@ export default function PopOver({
   onClose,
 }: PopOverProps) {
   const popOverRef = useRef<HTMLDivElement>(null);
-  const portalContainer = document.getElementById('popover-root');
+  const portalContainer = document.getElementById('popover-box');
 
   useOutSideClick({
     ref: popOverRef,

--- a/src/components/Common/TodayQuestion/TodayQuestion.module.scss
+++ b/src/components/Common/TodayQuestion/TodayQuestion.module.scss
@@ -5,9 +5,11 @@
   margin-bottom: 8px;
   position: relative;
   transition: 0.3s all;
+  border-width: 0px;
 
   @media (min-width: 768px) {
     margin-bottom: 12px;
+    border-width: 1px;
   }
 
   .question-title {

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -25,7 +25,6 @@ export default function App({ Component, pageProps }: AppProps) {
         </QueryProvider>
       </CookiesProvider>
       <div id="modal-root" />
-      <div id="popover-root" />
     </>
   );
 }


### PR DESCRIPTION
<!--타이틀은 아래처럼 적어주세요
ex) [Feat] 로그인 기능 추가
    [Fix] 로그인이 안되는 문제 수정-->

## 📃 관련 이슈
closed #75 
- 

## 💬 무슨 이유로 코드를 변경했는지
- 부모 위치를 불러올 수 없음에 따른 PC에서에 화면 틀어짐이 있었음. 그래서 해당 코드를 수정함.

## ❗ 어떤 위험이나 장애가 발견되었는지
- layout-sideBar 밑으로 portal div를 내렸더니 이번엔 스크롤을 내렸을때 같이 내려가버려서 그냥 portal div에도 classname을 지정해 스타일링 했음... 이게 맞는 방법인진 잘 모르겠음.

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  혹시 코드에 이상한게 있는지...

## ✅ 테스트 계획 또는 완료 사항
- 검색/알림 api 적용

## 🖼️ 관련 스크린샷
-
