### PR TITLE
[feat] 사용자 검색 화면 api 추가

### DIFF
--- a/src/components/Search/FollowButton/FollowButton.module.scss
+++ b/src/components/Search/FollowButton/FollowButton.module.scss
@@ -1,0 +1,24 @@
+.follow-button {
+  font-size: 1.4rem;
+  font-weight: 600;
+  width: 72px;
+  height: 32px;
+  border-radius: 5px;
+  border: none;
+  opacity: 0px;
+  color: $white-01;
+  background-color: $black-03;
+  cursor: pointer;
+
+  &.isActive {
+    background-color: $primary-01;
+  }
+}
+
+.delete-button {
+  @include font-style(1.4rem, $white-01, 600);
+  width: 72px;
+  height: 32px;
+  background: $black-03;
+  border-radius: 5px;
+}

--- a/src/components/Search/FollowButton/FollowButtonType.ts
+++ b/src/components/Search/FollowButton/FollowButtonType.ts
@@ -1,0 +1,4 @@
+export default interface FollowButtonType {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  isFollow: boolean | undefined;
+}

--- a/src/components/Search/FollowButton/index.tsx
+++ b/src/components/Search/FollowButton/index.tsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames/bind';
+import styles from './FollowButton.module.scss';
+import FollowButtonType from './FollowButtonType';
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { addFollow, deleteFollow } from '@/api/Follow';
+
+/**
+ * @param {function} onClick : 버튼 클릭 시 동작할 로직
+ * @param {boolean} isFollow : 팔로우 버튼인지 삭제 버튼인지 구분 , true: 팔로우/팔로잉 버튼 , false: 삭제 버튼
+ * @returns button
+ */
+
+const cn = classNames.bind(styles);
+
+export default function FollowButton({ onClick, isFollow }: FollowButtonType) {
+  const [isActive, setIsActive] = useState(false);
+
+  const memberId = 1;
+
+  const { mutate: mutateAdd } = useMutation({
+    mutationFn: addFollow,
+  });
+
+  const { mutate: mutateDelete } = useMutation({
+    mutationFn: deleteFollow,
+  });
+
+  // const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+  //   e.preventDefault();
+  //   setIsActive(!isActive);
+  //   onClick(memberId, isActive); // onClick prop으로 전달받은 함수를 호출
+  // };
+
+  return isFollow === true ? (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn('follow-button', { isActive })}
+    >
+      {isActive ? '팔로우' : '팔로잉'}
+    </button>
+  ) : (
+    <button type="button" className={cn('delete-button')}>
+      삭제
+    </button>
+  );
+}

--- a/src/components/Search/SearchAuthorProfile/SearchAuthorProfile.module.scss
+++ b/src/components/Search/SearchAuthorProfile/SearchAuthorProfile.module.scss
@@ -1,9 +1,49 @@
-.wrapper {
-  @include flex-arrange(center, center);
-  flex-direction: column;
-  gap: 12px;
+.search-profile {
+  @include glass-01;
+  @include flex-arrange(flex-start);
+  gap: 20px;
 
-  .nickname {
+  width: 100%;
+  padding: 30px 38px;
+  border-radius: 10px;
+  border-width: 0;
+  color: $white-01;
+
+  .profile-infomation {
+    @include flex-arrange(flex-start, flex-start);
+    gap: 12px;
+    flex-direction: column;
+
+    & > div {
+      @include flex-arrange(flex-start);
+    }
+  }
+
+  .profile-name {
     @include font-style(16px, $white-01, 700);
+    gap: 7px;
+  }
+
+  .profile-follow {
+    font-size: 14px;
+    gap: 20px;
+
+    & > div {
+      @include flex-arrange(flex-start);
+      gap: 8px;
+    }
+
+    span {
+      font-weight: 500;
+      color: $gray-02;
+    }
+
+    strong {
+      font-weight: 500;
+    }
+  }
+
+  .profile-description {
+    @include font-style(14px, $gray-01, 500);
   }
 }

--- a/src/components/Search/SearchAuthorProfile/SearchAuthorProfile.module.scss
+++ b/src/components/Search/SearchAuthorProfile/SearchAuthorProfile.module.scss
@@ -2,9 +2,9 @@
   @include glass-01;
   @include flex-arrange(flex-start);
   gap: 20px;
-
   width: 100%;
   padding: 30px 38px;
+  position: relative;
   border-radius: 10px;
   border-width: 0;
   color: $white-01;
@@ -45,5 +45,11 @@
 
   .profile-description {
     @include font-style(14px, $gray-01, 500);
+  }
+
+  button {
+    position: absolute;
+    top: 30px;
+    right: 23px;
   }
 }

--- a/src/components/Search/SearchAuthorProfile/index.tsx
+++ b/src/components/Search/SearchAuthorProfile/index.tsx
@@ -1,36 +1,48 @@
 import { Author } from '@/pages/post/[postId]/mockData';
 import classNames from 'classnames/bind';
-import Image from 'next/image';
 import styles from './SearchAuthorProfile.module.scss';
-import TermBadge from '@/components/Common/Badge/TermBadge';
+import Image from 'next/image';
+import GenerationBadge from '@/components/Common/GenerationBadge';
 
 interface SearchAuthorProfileProps {
   author: Author;
 }
 
-export default function SearchAuthorProfile({
-  author,
-}: SearchAuthorProfileProps) {
-  const cn = classNames.bind(styles);
-  const { nickname, profileImageUrl, generation } = author;
+const cn = classNames.bind(styles);
+
+export default function SearchAuthorProfile() {
   return (
-    <div className={cn('wrapper')}>
+    <div className={cn('search-profile')}>
       <Image
         className={cn('profile-image')}
-        src={profileImageUrl || '/images/profile.svg'}
+        src={
+          // profileImageUrl ||
+          '/images/profile.svg'
+        }
         alt="profile_image"
         width={86}
         height={86}
-        onClick={() => console.log('프로필 페이지로 이동')}
+        onClick={() => console.log('프로필모달 열기')}
       />
-      <button
-        type="button"
-        className={cn('nickname')}
-        onClick={() => console.log('프로필 페이지로 이동')}
-      >
-        {nickname}
-      </button>
-      <TermBadge term={generation} />
+      <div className={cn('profile-infomation')}>
+        <div className={cn('profile-name')}>
+          <h3>코스모스</h3>
+          <GenerationBadge />
+        </div>
+        <div className={cn('profile-follow')}>
+          <div>
+            <span>팔로워</span>
+            <strong>100</strong>
+          </div>
+          <div>
+            <span>팔로잉</span>
+            <strong>100</strong>
+          </div>
+        </div>
+        <div className={cn('profile-description')}>
+          <p>소개가 없습니다.</p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/Search/SearchAuthorProfile/index.tsx
+++ b/src/components/Search/SearchAuthorProfile/index.tsx
@@ -1,24 +1,39 @@
-import { Author } from '@/pages/post/[postId]/mockData';
+import { Member } from '../type';
 import classNames from 'classnames/bind';
 import styles from './SearchAuthorProfile.module.scss';
 import Image from 'next/image';
 import GenerationBadge from '@/components/Common/GenerationBadge';
+import FollowButton from '../FollowButton';
 
 interface SearchAuthorProfileProps {
-  author: Author;
+  member: Member;
 }
 
 const cn = classNames.bind(styles);
 
-export default function SearchAuthorProfile() {
+export default function SearchAuthorProfile({
+  member,
+}: SearchAuthorProfileProps) {
+  const {
+    nickname,
+    generation,
+    profileImageUrl,
+    introduce,
+    followerCount,
+    followingCount,
+    isFollowing,
+    isMine,
+  } = member;
+
+  // isFollowing은 팔로우 버튼 변하는거에 따라서... 수정해서 넣어야 할것같습니다! 그래서 일단 false로 통일합니다.
+
+  console.log(isFollowing);
+
   return (
     <div className={cn('search-profile')}>
       <Image
         className={cn('profile-image')}
-        src={
-          // profileImageUrl ||
-          '/images/profile.svg'
-        }
+        src={profileImageUrl || '/images/profile.svg'}
         alt="profile_image"
         width={86}
         height={86}
@@ -26,23 +41,30 @@ export default function SearchAuthorProfile() {
       />
       <div className={cn('profile-infomation')}>
         <div className={cn('profile-name')}>
-          <h3>코스모스</h3>
-          <GenerationBadge />
+          <h3>{nickname}</h3>
+          <GenerationBadge generationInfo={generation} />
         </div>
         <div className={cn('profile-follow')}>
           <div>
             <span>팔로워</span>
-            <strong>100</strong>
+            <strong>{followerCount}</strong>
           </div>
           <div>
             <span>팔로잉</span>
-            <strong>100</strong>
+            <strong>{followingCount}</strong>
           </div>
         </div>
         <div className={cn('profile-description')}>
-          <p>소개가 없습니다.</p>
+          <p>{introduce || '소개가 없습니다.'}</p>
         </div>
       </div>
+
+      {!isMine && (
+        <FollowButton
+          onClick={() => console.log('팔로우클릭')}
+          isFollow={false}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Search/SearchAuthorProfileList/SearchAuthorProfileList.module.scss
+++ b/src/components/Search/SearchAuthorProfileList/SearchAuthorProfileList.module.scss
@@ -1,11 +1,9 @@
 .wrapper {
   display: grid;
   padding: 26px;
-  grid-template-columns: 1fr 1fr 1fr;
   gap: 25px;
 
   @media (min-width: 768px) {
-    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
     padding: 32px;
   }
 }

--- a/src/components/Search/SearchAuthorProfileList/index.tsx
+++ b/src/components/Search/SearchAuthorProfileList/index.tsx
@@ -1,55 +1,53 @@
 import classNames from 'classnames/bind';
 import styles from './SearchAuthorProfileList.module.scss';
 import SearchAuthorProfile from '../SearchAuthorProfile';
+import { SearchMemberResultData } from '@/components/Search/type';
+import { useQuery } from '@tanstack/react-query';
+import fetchData from '@/api/fetchData';
+import NoSearchResult from '@/components/Search/NoSearchResult';
+import LoadingSpinner from '@/components/Common/LoadingSpinner';
 
 const cn = classNames.bind(styles);
 
-export default function SearchAuthorProfileList() {
-  const mockData = [
-    {
-      id: '고유값1',
-      nickname: '사용자1',
-      profileImageUrl: '',
-      generation: 3,
-    },
-    {
-      id: '고유값2',
-      nickname: '사용자2',
-      profileImageUrl: '',
-      generation: 3,
-    },
-    {
-      id: '고유값3',
-      nickname: '사용자3',
-      profileImageUrl: '',
-      generation: 3,
-    },
-    {
-      id: '고유값4',
-      nickname: '사용자4',
-      profileImageUrl: '',
-      generation: 1,
-    },
-    {
-      id: '고유값5',
-      nickname: '사용자5',
-      profileImageUrl: '',
-      generation: 2,
-    },
-    {
-      id: '고유값6',
-      nickname: '사용자6',
-      profileImageUrl: '',
-      generation: 1,
-    },
-  ];
+interface SearchAuthorProfileListProps {
+  keyword: string;
+}
+
+export default function SearchAuthorProfileList({
+  keyword,
+}: SearchAuthorProfileListProps) {
+  const {
+    data: searchProfileResult,
+    isLoading,
+    isSuccess,
+  } = useQuery<SearchMemberResultData>({
+    queryKey: ['searchProfileList', keyword],
+    queryFn: () =>
+      fetchData({
+        param: `/search/member/name?order=DESC&page=1&take=4&keyword=${keyword}`,
+      }),
+  });
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (
+    !isSuccess ||
+    !searchProfileResult.data ||
+    searchProfileResult.data.length === 0
+  ) {
+    return <NoSearchResult />;
+  }
 
   return (
     <div className={cn('wrapper')}>
-      {/* {mockData.map((author) => (
-        <SearchAuthorProfile key={author.id} author={author} />
-      ))} */}
-      <SearchAuthorProfile />
+      {searchProfileResult.data.map((profileData) => (
+        <SearchAuthorProfile
+          key={profileData.member.id}
+          member={profileData.member}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/Search/SearchAuthorProfileList/index.tsx
+++ b/src/components/Search/SearchAuthorProfileList/index.tsx
@@ -46,9 +46,10 @@ export default function SearchAuthorProfileList() {
 
   return (
     <div className={cn('wrapper')}>
-      {mockData.map((author) => (
+      {/* {mockData.map((author) => (
         <SearchAuthorProfile key={author.id} author={author} />
-      ))}
+      ))} */}
+      <SearchAuthorProfile />
     </div>
   );
 }

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -1,18 +1,42 @@
 import SearchPreview from '../SearchPriview';
-import { SearchData } from '../type';
+import { SearchResult } from '../type';
 import styles from './SearchList.module.scss';
 import classNames from 'classnames/bind';
+import { useQuery } from '@tanstack/react-query';
+import LoadingSpinner from '@/components/Common/LoadingSpinner';
+import NoSearchResult from '@/components/Search/NoSearchResult';
+import fetchData from '@/api/fetchData';
 
 interface SearchListProps {
-  searchList: SearchData[];
+  keyword: string;
 }
 
 const cn = classNames.bind(styles);
 
-export default function SearchList({ searchList }: SearchListProps) {
+export default function SearchList({ keyword }: SearchListProps) {
+  const {
+    data: searchList,
+    isLoading,
+    isSuccess,
+  } = useQuery<SearchResult>({
+    queryKey: ['searchList', keyword],
+    queryFn: () =>
+      fetchData({
+        param: `/search/post/hash-tag?order=DESC&page=1&take=4&keyword=${keyword}`,
+      }),
+  });
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (!isSuccess || !searchList.data || searchList.data.length === 0) {
+    return <NoSearchResult />;
+  }
+
   return (
     <div className={cn('search-list')}>
-      {searchList.map((searchData) => (
+      {searchList.data.map((searchData) => (
         <SearchPreview key={searchData.post.id} searchData={searchData} />
       ))}
     </div>

--- a/src/components/Search/type.ts
+++ b/src/components/Search/type.ts
@@ -33,3 +33,24 @@ export interface SearchResult {
   data: SearchData[];
   meta: Meta;
 }
+
+export interface Member {
+  id: number;
+  nickname: string;
+  generation: number | null;
+  profileImageUrl: string | null;
+  introduce: string | null;
+  followerCount: number;
+  followingCount: number;
+  isFollowing: number;
+  isMine: boolean;
+}
+
+export interface MemberData {
+  member: Member;
+}
+
+export interface SearchMemberResultData {
+  data: MemberData[];
+  meta: Meta;
+}

--- a/src/pages/search/index.page.tsx
+++ b/src/pages/search/index.page.tsx
@@ -1,14 +1,9 @@
 import { ContainerOptionType } from '@/@types/type';
 import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import ContentContainer from '@/components/Common/ContentContainer';
 import SearchAuthorProfileList from '@/components/Search/SearchAuthorProfileList';
 import SearchList from '@/components/Search/SearchList';
-import { SearchResult } from '@/components/Search/type';
-import NoSearchResult from '@/components/Search/NoSearchResult';
-import LoadingSpinner from '@/components/Common/LoadingSpinner';
-import fetchData from '@/api/fetchData';
 
 export default function SearchResultPage() {
   const [selectedOption, setSelectedOption] =
@@ -16,29 +11,12 @@ export default function SearchResultPage() {
   const searchParams = useSearchParams();
   const keyword: string = searchParams.get('query') || '';
 
-  const { data: searchResult, isLoading } = useQuery<SearchResult>({
-    queryKey: ['searchList', keyword],
-    queryFn: () =>
-      fetchData({
-        param: `/search/post/hash-tag?order=DESC&page=1&take=4&keyword=${keyword}`,
-      }),
-  });
-
   let searchResultComponent;
-
-  if (isLoading) {
-    searchResultComponent = <LoadingSpinner />;
-  } else if (!searchResult || searchResult.data.length === 0) {
-    searchResultComponent = <NoSearchResult />;
+  if (selectedOption === 'hashtag') {
+    searchResultComponent = <SearchList keyword={keyword} />;
   } else {
-    searchResultComponent =
-      selectedOption === 'hashtag' ? (
-        <SearchList searchList={searchResult.data} />
-      ) : (
-        <SearchAuthorProfileList />
-      );
+    searchResultComponent = <SearchAuthorProfileList keyword={keyword} />;
   }
-
   return (
     <ContentContainer
       selectedOption={selectedOption}


### PR DESCRIPTION
## 📃 관련 이슈
closed #89 
- 

## 💬 무슨 이유로 코드를 변경했는지
- 사용자 검색 api 화면 추가 및 useQuery 상세 컴포넌트로 이동

## ❗ 어떤 위험이나 장애가 발견되었는지
- X

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  팔로잉/팔로우 버튼 대응 처리가 필요함(다른분들 코드 올라오면 적용할게요.)
- (잡담) 코딩 자아가 왔다갔다 하네요 뭐 하나 완료하면 좀 쉬다 하는데 쉬다 오면 a로 입력했던 변수값 b로 막입력하고 제 정체성을 찾고싶은 기분입니다 ㅎ; ㅜ... 얼마든지 지적해주세요. 수정하겠습니다. 

## ✅ 테스트 계획 또는 완료 사항
- 알림 api get 요청 및 타입 분기 처리
- 검색 key값 전역화(월요일 중간점검 이후 예정)
- 프로필 화면이 나오면..!!! 프로필 화면으로 이동하도록 라우터 처리를 주가해야합니다.
- 무한스크롤
- 여러가지 리팩토링

## 🖼️ 관련 스크린샷
![image](https://github.com/project-cosmo-sns/cosmos/assets/49646127/d6b45943-3f20-4653-931b-c3814b0ef4cf)

