### PR TITLE
[feat] 알림 api 적용

### DIFF
--- a/src/components/Common/Layout/Notification/NotificationItem/NotificationItem.module.scss
+++ b/src/components/Common/Layout/Notification/NotificationItem/NotificationItem.module.scss
@@ -1,9 +1,11 @@
 .notification-item {
   @include flex-arrange(space-between, center);
   gap: 12px;
-  margin-bottom: 12px;
+  padding: 6px 0;
   line-height: 1.5em;
   color: $white-01;
+  cursor: pointer;
+  border-radius: 10px;
 
   @media (min-width: 768px) {
     gap: 6px;
@@ -35,5 +37,9 @@
     &.isRead {
       background: transparent;
     }
+  }
+
+  &:hover {
+    background-color: $black-02;
   }
 }

--- a/src/components/Common/Layout/Notification/NotificationItem/index.tsx
+++ b/src/components/Common/Layout/Notification/NotificationItem/index.tsx
@@ -2,8 +2,9 @@ import classNames from 'classnames/bind';
 import styles from './NotificationItem.module.scss';
 import { ProfileIconDark } from '@/components/Common/IconCollection';
 import Image from 'next/image';
-import { NotificationData } from '../type';
+import { NotificationData, notificationType } from '../type';
 import getElapsedTime from '@/utils/getElaspedTime';
+import { useRouter } from 'next/router';
 
 const cn = classNames.bind(styles);
 
@@ -14,15 +15,28 @@ type NotificationItemProps = {
 export default function NotificationItem({ data }: NotificationItemProps) {
   const {
     sendMember,
-    notification: { content, notificationType, isConfirmed, createdAt },
+    notification: {
+      content,
+      notificationType: { type, feedId, postId },
+      isConfirmed,
+      createdAt,
+    },
   } = data;
 
   // notificationType따른 동작 분기 처리가 필요함. 피드/팔로우...가 들어오면? 해볼까? 임시로 포스트부터 붙여보기.
 
+  const router = useRouter();
+
+  const handleNotificationClick = () => {
+    if (type === notificationType.CREATE_POST_COMMENT) {
+      router.push(`/post/${postId}/detail`);
+    }
+  };
+
   const formattedCreatedAt = getElapsedTime(createdAt);
 
   return (
-    <div className={cn('notification-item')}>
+    <div className={cn('notification-item')} onClick={handleNotificationClick}>
       {sendMember.profileImageUrl ? (
         <Image src={sendMember.profileImageUrl} alt="프로필 이미지" />
       ) : (

--- a/src/components/Common/Layout/Notification/NotificationItem/index.tsx
+++ b/src/components/Common/Layout/Notification/NotificationItem/index.tsx
@@ -2,44 +2,37 @@ import classNames from 'classnames/bind';
 import styles from './NotificationItem.module.scss';
 import { ProfileIconDark } from '@/components/Common/IconCollection';
 import Image from 'next/image';
+import { NotificationData } from '../type';
+import getElapsedTime from '@/utils/getElaspedTime';
 
 const cn = classNames.bind(styles);
 
-// 임시 타입
-type Notification = {
-  author: {
-    nickname: string;
-    profileImage: string | null;
-  };
-  text: string;
-  createdAt: string;
-  isRead: boolean;
-};
-
 type NotificationItemProps = {
-  data: Notification;
+  data: NotificationData;
 };
 
 export default function NotificationItem({ data }: NotificationItemProps) {
   const {
-    author: { nickname, profileImage },
-    text,
-    createdAt,
-    isRead,
+    sendMember,
+    notification: { content, notificationType, isConfirmed, createdAt },
   } = data;
+
+  // notificationType따른 동작 분기 처리가 필요함. 피드/팔로우...가 들어오면? 해볼까? 임시로 포스트부터 붙여보기.
+
+  const formattedCreatedAt = getElapsedTime(createdAt);
+
   return (
-    // 날짜 관련은 데이터 들어오는것 보고...! 추가로 수정하겠습니다
     <div className={cn('notification-item')}>
-      {profileImage ? (
-        <Image src="profileImage" alt="프로필 이미지" />
+      {sendMember.profileImageUrl ? (
+        <Image src={sendMember.profileImageUrl} alt="프로필 이미지" />
       ) : (
         <ProfileIconDark width="54" height="54" />
       )}
       <p>
-        <strong>{nickname}</strong>님이 {text} 했습니다.
-        <span>{createdAt}</span>
+        <strong>{content}</strong>
+        <span>{formattedCreatedAt}</span>
       </p>
-      <span className={cn('notification-dot', { isRead })} />
+      <span className={cn('notification-dot', { isConfirmed })} />
     </div>
   );
 }

--- a/src/components/Common/Layout/Notification/index.tsx
+++ b/src/components/Common/Layout/Notification/index.tsx
@@ -5,6 +5,10 @@ import NotificationItem from './NotificationItem';
 import { BackIcon, SettingIcon } from '../../IconCollection';
 import { useState } from 'react';
 import NotificationModal from './NotificationModal';
+import { NotificationResult } from './type';
+import { useQuery } from '@tanstack/react-query';
+import fetchData from '@/api/fetchData';
+import LoadingSpinner from '@/components/Common/LoadingSpinner';
 
 type PopOverProps = {
   onClose: () => void;
@@ -15,63 +19,25 @@ const cn = classNames.bind(styles);
 export default function Notification({ onClose }: PopOverProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const mockData = [
-    {
-      id: 1,
-      author: {
-        id: '아이디',
-        nickname: '닉네임',
-        profileImage: null,
-      },
-      text: '무슨 텍스트가 올까요...?',
-      createdAt: '2시간 전',
-      isRead: false,
-    },
-    {
-      id: 2,
-      author: {
-        id: '아이디',
-        nickname: '닉네임',
-        profileImage: null,
-      },
-      text: '무슨 텍스트가 올까요...?',
-      createdAt: '2시간 전',
-      isRead: false,
-    },
-    {
-      id: 3,
-      author: {
-        id: '아이디',
-        nickname: '닉네임',
-        profileImage: null,
-      },
-      text: '무슨 텍스트가 올까요...?',
-      createdAt: '2시간 전',
-      isRead: false,
-    },
-    {
-      id: 4,
-      author: {
-        id: '아이디',
-        nickname: '닉네임',
-        profileImage: null,
-      },
-      text: '무슨 텍스트가 올까요...?',
-      createdAt: '2시간 전',
-      isRead: false,
-    },
-    {
-      id: 5,
-      author: {
-        id: '아이디',
-        nickname: '닉네임',
-        profileImage: null,
-      },
-      text: '무슨 텍스트가 올까요...?',
-      createdAt: '2시간 전',
-      isRead: true,
-    },
-  ];
+  const {
+    data: notification,
+    isLoading,
+    isSuccess,
+  } = useQuery<NotificationResult>({
+    queryKey: ['notification'],
+    queryFn: () =>
+      fetchData({
+        param: `/notification/list?order=DESC&page=1&take=10`,
+      }),
+  });
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (!isSuccess || !notification.data || notification.data.length === 0) {
+    return <div>알림이 없습니다.</div>;
+  }
 
   return (
     <PopOver onClose={onClose} className={cn('notification-popover')}>
@@ -88,9 +54,13 @@ export default function Notification({ onClose }: PopOverProps) {
         fill="#C2C7D9"
       />
 
-      {mockData.map((notification) => (
-        <NotificationItem key={notification.id} data={notification} />
+      {notification.data.map((notificationitem) => (
+        <NotificationItem
+          key={notificationitem.notification.id}
+          data={notificationitem}
+        />
       ))}
+
       {isModalOpen && (
         <NotificationModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
       )}

--- a/src/components/Common/Layout/Notification/index.tsx
+++ b/src/components/Common/Layout/Notification/index.tsx
@@ -20,7 +20,7 @@ export default function Notification({ onClose }: PopOverProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const {
-    data: notification,
+    data: notificationList,
     isLoading,
     isSuccess,
   } = useQuery<NotificationResult>({
@@ -35,9 +35,19 @@ export default function Notification({ onClose }: PopOverProps) {
     return <LoadingSpinner />;
   }
 
-  if (!isSuccess || !notification.data || notification.data.length === 0) {
+  if (
+    !isSuccess ||
+    !notificationList.data ||
+    notificationList.data.length === 0
+  ) {
     return <div>알림이 없습니다.</div>;
   }
+
+  // 알림... 팝오버를 켰을때 보이는 알림들을 리스트 뽑아서 한꺼번에 읽음 처리 하고 싶은데 하나씩 보내게 되어있음. 고민좀 해봐야 할듯... 하나씩 읽음 처리 한다면 읽음 버튼이 있어야 하지 않을까?
+  // 본인 알림 목록에 isConfirmed이 false인게 1개라도 있으면 알림쪽에 dot 표시도 해야하는데. 이것도 고민좀하고 적용해야됨.
+  const notificationIds = notificationList.data.map(
+    (item) => item.notification.id,
+  );
 
   return (
     <PopOver onClose={onClose} className={cn('notification-popover')}>
@@ -54,7 +64,7 @@ export default function Notification({ onClose }: PopOverProps) {
         fill="#C2C7D9"
       />
 
-      {notification.data.map((notificationitem) => (
+      {notificationList.data.map((notificationitem) => (
         <NotificationItem
           key={notificationitem.notification.id}
           data={notificationitem}

--- a/src/components/Common/Layout/Notification/type.ts
+++ b/src/components/Common/Layout/Notification/type.ts
@@ -1,0 +1,42 @@
+export enum notificationType {
+  CREATE_FEED_COMMENT = 'CREATE_FEED_COMMENT',
+  CREATE_POST_COMMENT = 'CREATE_POST_COMMENT',
+  CREATE_FEED_EMOJI = 'CREATE_FEED_EMOJI',
+  CREATE_POST_EMOJI = 'CREATE_POST_EMOJI',
+}
+
+interface NotificationType {
+  type: notificationType;
+  feedId?: number;
+  postId?: number;
+  commentId?: number;
+}
+
+interface SendMember {
+  profileImageUrl: string | null;
+}
+
+interface Notification {
+  id: number;
+  content: string;
+  notificationType: NotificationType;
+  isConfirmed: boolean;
+  createdAt: string;
+}
+
+export interface NotificationData {
+  sendMember: SendMember;
+  notification: Notification;
+}
+
+export interface NotificationResult {
+  data: NotificationData[];
+  meta: {
+    page: number;
+    take: number;
+    totalCount: number;
+    pageCount: number;
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+  };
+}

--- a/src/components/Search/SearchAuthorProfile/index.tsx
+++ b/src/components/Search/SearchAuthorProfile/index.tsx
@@ -27,8 +27,6 @@ export default function SearchAuthorProfile({
 
   // isFollowing은 팔로우 버튼 변하는거에 따라서... 수정해서 넣어야 할것같습니다! 그래서 일단 false로 통일합니다.
 
-  console.log(isFollowing);
-
   return (
     <div className={cn('search-profile')}>
       <Image


### PR DESCRIPTION
## 📃 관련 이슈
closed #77 
- 

## 💬 무슨 이유로 코드를 변경했는지
- 알림 api 적용

## ❗ 어떤 위험이나 장애가 발견되었는지
- x

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  알림 확인 처리에 대해 고민해봤는데, 그 고민이... 주석에 담겨있습니다... 내일 말씀드릴게요.
- 일단 완료된 post라도 분기...처리? (라고 해야하나요?) 를 해놨습니다... 
- 코드 이상한 부분 있으면 언제든 말씀해주세요...
- 오늘. 멘토링때 봬요. ^^ 

## ✅ 테스트 계획 또는 완료 사항
- 검색어 key값 전역화
- 검색화면 PostPreview 가져다쓰기
- 유정님이 해주신거 활용해서 SSR 적용
- 프로필화면 나올시 사용자 검색화면 라우터 처리
- 검색/알림 둘 다 무한스크롤 적용
- 알림 확인처리(고민좀해보고)
- 새로운 알림 있을시 layout 종 아이콘 옆에 dot 띄우기
- 알림 설정 api 나오면 적용해야함.
- 모바일 검색 어떻게할지... 고민 후 개선
- 알림 모달 모바일에서 스크롤으로 조정할 수 있게끔 라이브러리 찾아보기  
- 코드 리팩토링
- 시간 남으면 모달 배경 스크롤 없애기?

## 🖼️ 관련 스크린샷

![image](https://github.com/project-cosmo-sns/cosmos/assets/49646127/ed7f7d7a-22e8-4f0c-afc8-04992db9de18)
