### PR TITLE
[Feature] 포스트 댓글 작성 및 초기 데이터 10개, 삭제 모달 생성

### DIFF
--- a/src/components/Common/DeleteModal/DeleteModal.module.scss
+++ b/src/components/Common/DeleteModal/DeleteModal.module.scss
@@ -1,0 +1,34 @@
+.wrapper {
+  @include flex-arrange;
+  @include font-style(2rem, $white-01, 700);
+  flex-direction: column;
+  padding: 30px 10px 10px;
+  gap: 40px;
+}
+
+.button-container {
+  @include flex-arrange;
+  gap: 8px;
+}
+
+.button {
+  @include font-style(1.6rem, $white-01, 700);
+  padding: 14px 50px;
+  border-radius: 5px;
+}
+
+.delete {
+  background-color: $pink-01;
+
+  &:hover {
+    background-color: $red-01;
+  }
+}
+
+.cancel {
+  background-color: $black-03;
+
+  &:hover {
+    background-color: $black-02;
+  }
+}

--- a/src/components/Common/DeleteModal/DeleteModal.module.scss
+++ b/src/components/Common/DeleteModal/DeleteModal.module.scss
@@ -2,7 +2,7 @@
   @include flex-arrange;
   @include font-style(2rem, $white-01, 700);
   flex-direction: column;
-  padding: 30px 10px 10px;
+  margin-top: -20px;
   gap: 40px;
 }
 
@@ -13,7 +13,7 @@
 
 .button {
   @include font-style(1.6rem, $white-01, 700);
-  padding: 14px 50px;
+  padding: 14px 40px;
   border-radius: 5px;
 }
 
@@ -30,5 +30,16 @@
 
   &:hover {
     background-color: $black-02;
+  }
+}
+
+@media (min-width: 768px) {
+  .wrapper {
+    margin-top: 0;
+    padding: 30px 10px 10px;
+  }
+
+  .button {
+    padding: 14px 50px;
   }
 }

--- a/src/components/Common/DeleteModal/index.tsx
+++ b/src/components/Common/DeleteModal/index.tsx
@@ -1,0 +1,46 @@
+import classNames from 'classnames/bind';
+import Modal from '../Layout/Modal';
+import styles from './DeleteModal.module.scss';
+
+interface DeleteModalProps {
+  isDeleteModalOpen: boolean;
+  setIsDeleteModalOpen: (args: boolean) => void;
+  handleDelete: () => void;
+}
+
+const cn = classNames.bind(styles);
+
+export default function DeleteModal({
+  isDeleteModalOpen,
+  setIsDeleteModalOpen,
+  handleDelete,
+}: DeleteModalProps) {
+  return (
+    <Modal
+      modalVisible={isDeleteModalOpen}
+      toggleModal={() => setIsDeleteModalOpen(false)}
+      cssModalSize={cn()}
+      cssComponentDisplay={cn()}
+    >
+      <div className={cn('wrapper')}>
+        <span>정말 삭제하시겠습니까?</span>
+        <div className={cn('button-container')}>
+          <button
+            className={cn('button', 'cancel')}
+            type="button"
+            onClick={() => setIsDeleteModalOpen(false)}
+          >
+            취소하기
+          </button>
+          <button
+            className={cn('button', 'delete')}
+            type="button"
+            onClick={handleDelete}
+          >
+            삭제하기
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Post/PostComment/PostComment.module.scss
+++ b/src/components/Post/PostComment/PostComment.module.scss
@@ -2,6 +2,7 @@
   @include flex-arrange(center, flex-start);
   flex-direction: column;
   width: 100%;
+  margin-top: 20px;
 }
 
 .comment-container {

--- a/src/components/Post/PostComment/index.tsx
+++ b/src/components/Post/PostComment/index.tsx
@@ -4,29 +4,54 @@ import { CommentListType } from '@/components/Feed/types';
 import classNames from 'classnames/bind';
 import styles from './PostComment.module.scss';
 import { useRouter } from 'next/router';
+import { useCommentRequest } from '@/hooks/useCommentRequest';
+import { useQuery } from '@tanstack/react-query';
+import fetchData from '@/api/fetchData';
 
 interface PostCommentProps {
-  commentData: CommentListType;
+  postId: number;
 }
 
 const cn = classNames.bind(styles);
 
-export default function PostComment({ commentData }: PostCommentProps) {
-  const { data } = commentData;
+export default function PostComment({ postId }: PostCommentProps) {
   const router = useRouter();
-  const { postId } = router.query;
-  const { totalCount } = commentData.meta;
+
+  const {
+    onSubmit,
+    deleteCommentRequest,
+    postLikeRequest,
+    deleteLikeRequest,
+    editCommentRequest,
+  } = useCommentRequest(postId, false);
+
+  const { data: commentData } = useQuery<CommentListType>({
+    queryKey: ['commentList', postId],
+    queryFn: () => fetchData({ param: `/post/${postId}/comment/list` }),
+  });
 
   return (
     <div className={cn('wrapper')}>
-      {/* <CommentInput placeholder="댓글을 입력하세요" feedId={Number(postId)} /> */}
+      <CommentInput placeholder="댓글을 입력하세요" onSubmit={onSubmit} />
       <div className={cn('comment-container')}>
-        {/* {data.map((comment, index) => (
-          <div key={comment.comment.id}>
-            <CommentCard comment={comment} />
-            {index === data.length - 1 || <div className={cn('divide-line')} />}
-          </div>
-        ))} */}
+        {commentData ? (
+          commentData.data.map((comment, index) => (
+            <div key={comment.comment.id}>
+              <CommentCard
+                comment={comment}
+                deleteLikeRequest={deleteLikeRequest}
+                postLikeRequest={postLikeRequest}
+                deleteCommentRequest={deleteCommentRequest}
+                editCommentRequest={editCommentRequest}
+              />
+              {index === commentData.data.length - 1 || (
+                <div className={cn('divide-line')} />
+              )}
+            </div>
+          ))
+        ) : (
+          <>없어</>
+        )}
       </div>
     </div>
   );

--- a/src/components/Post/PostContent/PostContent.module.scss
+++ b/src/components/Post/PostContent/PostContent.module.scss
@@ -29,6 +29,7 @@
 
 .markdown-content {
   @include markdown-style;
+  max-width: 100%;
 }
 
 .hashtag-container {

--- a/src/components/Post/PostContent/index.tsx
+++ b/src/components/Post/PostContent/index.tsx
@@ -1,8 +1,8 @@
 import fetchData from '@/api/fetchData';
-import WriterProfile from '@/components/Common/WriterProfile';
 import ActionButtons from '@/components/Common/Buttons/ActionButtons';
+import DeleteModal from '@/components/Common/DeleteModal';
 import EmojiBundle from '@/components/Common/EmojiBundle';
-import Modal from '@/components/Common/Layout/Modal';
+import WriterProfile from '@/components/Common/WriterProfile';
 import useSendEmojiRequest from '@/hooks/useSendEmojiRequest';
 import { useMutation } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
@@ -10,10 +10,9 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import HashTag from '../HashTag';
 import MarkdownContent from '../Markdown';
+import PostComment from '../PostComment';
 import { HashTagType, PostDetailType } from '../types';
 import styles from './PostContent.module.scss';
-import CommentCard from '@/components/Common/CommentCard';
-import PostComment from '../PostComment';
 
 interface PostContentProps {
   postData: PostDetailType;
@@ -63,20 +62,11 @@ export default function PostContent({ postData }: PostContentProps) {
           handleClickEdit={() => router.push(`/write?postId=${postId}`)}
           handleClickDelete={() => setIsDeleteModalOpen(true)}
         />
-        <Modal
-          modalVisible={isDeleteModalOpen}
-          toggleModal={setIsDeleteModalOpen}
-          cssComponentDisplay={cn('')}
-          cssModalSize={cn('')}
-        >
-          <div>삭제하시겠습니까?</div>
-          <button type="button" onClick={() => deleteMutate()}>
-            예
-          </button>
-          <button type="button" onClick={() => setIsDeleteModalOpen(false)}>
-            아니오
-          </button>
-        </Modal>
+        <DeleteModal
+          isDeleteModalOpen={isDeleteModalOpen}
+          setIsDeleteModalOpen={setIsDeleteModalOpen}
+          handleDelete={deleteMutate}
+        />
       </div>
       <div className={cn('divide-line')} />
       <MarkdownContent className={cn('markdown-content')} content={content} />

--- a/src/components/Post/PostContent/index.tsx
+++ b/src/components/Post/PostContent/index.tsx
@@ -12,6 +12,8 @@ import HashTag from '../HashTag';
 import MarkdownContent from '../Markdown';
 import { HashTagType, PostDetailType } from '../types';
 import styles from './PostContent.module.scss';
+import CommentCard from '@/components/Common/CommentCard';
+import PostComment from '../PostComment';
 
 interface PostContentProps {
   postData: PostDetailType;
@@ -91,6 +93,7 @@ export default function PostContent({ postData }: PostContentProps) {
         handleEmojiClick={handleEmojiClick}
         isPending={isAddPending || isDeletePending}
       />
+      <PostComment postId={Number(postId)} />
     </div>
   );
 }

--- a/src/components/Post/PostContent/index.tsx
+++ b/src/components/Post/PostContent/index.tsx
@@ -56,7 +56,10 @@ export default function PostContent({ postData }: PostContentProps) {
       <span className={cn('category')}>{category}</span>
       <span className={cn('title')}>{title}</span>
       <div className={cn('header')}>
-        <WriterProfile writer={writer} createdAt={createdAt} />
+        <WriterProfile
+          writer={writer}
+          createdAt={createdAt.slice(0, 10).replace(/-/g, '.')}
+        />
         <ActionButtons
           isButtonShow={isMine}
           handleClickEdit={() => router.push(`/write?postId=${postId}`)}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -19,8 +19,8 @@ $glass-02: rgba(88, 92, 109, 0.4);
 
 $glass-edge-01: 1px solid rgba(255, 255, 255, 0.15);
 
-$red-01: #ff5151;
-$red-02: #ffeaea;
+$pink-01: #ff5151;
+$pink-02: #ffeaea;
 
 $orange-01: #ff7512;
 $orange-02: #ffe1cc;
@@ -39,8 +39,8 @@ $purple-02: #f0e4ff;
 
 $hashtag-colors: (
   RED: (
-    $red-02,
-    $red-01,
+    $pink-02,
+    $pink-01,
   ),
   ORANGE: (
     $orange-02,


### PR DESCRIPTION
 

## 💬 무슨 이유로 코드를 변경했는지
- 포스트 댓글 api 연결했습니다
- 아직 무한스크롤 구현전이라 10개까지 불러옵니다!
- 삭제 모달 생성

## ❗ 어떤 위험이나 장애가 발견되었는지
- 

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  

## ✅ 테스트 계획 또는 완료 사항
- 포스트 목록 무한스크롤 (카테고리 코드도 쿼리로 추가해주셔야 가능할듯..?)
- 댓글 목록 무한스크롤
- 편집기에서 이미지 업로드 시 텍스트로 띄우기 (80% 정도 완료..?)
- 해시태그 키보드 이벤트와 마우스이벤트 통일하기 

## 🖼️ 관련 스크린샷
<img width="669" alt="image" src="https://github.com/project-cosmo-sns/cosmos/assets/127701092/57d5f81c-ffef-488a-9240-3cc8eead7baf">

