### PR TITLE
[Feat] 프로필 페이지 오류 해결, 팔로우 버튼 수정 

### DIFF
--- a/src/components/Common/Buttons/FollowButton/FollowButton.module.scss
+++ b/src/components/Common/Buttons/FollowButton/FollowButton.module.scss
@@ -7,11 +7,13 @@
   border: none;
   opacity: 0px;
   color: $white-01;
-  background-color: $black-03;
+  background-color: $primary-01;
+  // background-color: $black-01;
   cursor: pointer;
 
   &.isActive {
-    background-color: $primary-01;
+    // background-color: $primary-01;
+    background-color: $black-01;
   }
 }
 

--- a/src/components/Common/Buttons/FollowButton/index.tsx
+++ b/src/components/Common/Buttons/FollowButton/index.tsx
@@ -26,7 +26,7 @@ export default function FollowButton({
       onClick={handleClick}
       className={cn('follow-button', { isActive })}
     >
-      {isActive ? '팔로우' : '팔로잉'}
+      {isActive ? '팔로잉' : '팔로우'}
     </button>
   ) : (
     <button type="button" className={cn('delete-button')}>

--- a/src/components/Profile/ProfileEditModal/ProfileEditModal.module.scss
+++ b/src/components/Profile/ProfileEditModal/ProfileEditModal.module.scss
@@ -14,24 +14,6 @@
   margin-top: 40px;
 }
 
-// .profile-image {
-//   z-index: 1;
-// }
-
-// .camera-image {
-//   @include flex-arrange;
-//   position: absolute;
-//   z-index: 2;
-//   left: 58px;
-//   top: 58px;
-//   background-color: $white-01;
-//   width: 28px;
-//   height: 28px;
-//   border-radius: 50%;
-//   border: 1px solid $gray-02;
-//   cursor: pointer;
-// }
-
 .name {
   font-weight: 700;
   margin-bottom: 8px;

--- a/src/components/Profile/ProfileEditModal/getImageUploadUrl.ts
+++ b/src/components/Profile/ProfileEditModal/getImageUploadUrl.ts
@@ -7,7 +7,7 @@ interface FetchDataResponse {
 // 이 과정을 통해서는 이미지 url을 받는게 아니다.
 // 그냥 S3버킷에 업로드 가능한 pre-signed URL만 받고
 // 이걸 이용해서 이미지를 S3에 업로드하는것
-export default async function GetUploadUrl() {
+export default async function GetUpImageloadUrl() {
   try {
     const response = (await fetchData({
       param: '/profile/image/create',

--- a/src/components/Profile/ProfileEditModal/index.tsx
+++ b/src/components/Profile/ProfileEditModal/index.tsx
@@ -118,7 +118,7 @@ export default function ProfileEditModal({
     try {
       const requestData = {
         nickname: memberData.nickname,
-        introduce: newIntroduce || memberData.introduce || '입력하세요',
+        introduce: newIntroduce || memberData.introduce || '',
         profileImageUrl: profileImageUrl || memberData.profileImageUrl || null,
       };
 
@@ -129,7 +129,6 @@ export default function ProfileEditModal({
       });
 
       console.log('프로필 업데이트 성공:', response);
-      // 프로필 업데이트 후 모달 닫고 리패치 해야함
       await refetchProfile();
       setIsOpen(false);
       router.reload();

--- a/src/components/Profile/ProfileEditModal/index.tsx
+++ b/src/components/Profile/ProfileEditModal/index.tsx
@@ -11,6 +11,7 @@ import GetProfileImageUrl from './getImageUploadUrl';
 import fetchData from '@/api/fetchData';
 import { AuthFormProps } from '@/@types/type';
 import { uploadImageToS3 } from './uploadImageToS3';
+import router from 'next/router';
 
 interface ProfileEditModalProps {
   isOpen: boolean;
@@ -131,6 +132,7 @@ export default function ProfileEditModal({
       // 프로필 업데이트 후 모달 닫고 리패치 해야함
       await refetchProfile();
       setIsOpen(false);
+      router.reload();
     } catch (error) {
       console.error('프로필 업데이트 에러:', error);
     }

--- a/src/components/Profile/ProfileEditModal/index.tsx
+++ b/src/components/Profile/ProfileEditModal/index.tsx
@@ -55,18 +55,6 @@ export default function ProfileEditModal({
     }
   }, [memberData.introduce, setValue]);
 
-  useEffect(() => {
-    if (upLoadComplete) {
-      if (uploadedImageUrl) {
-        setImageUrl(uploadedImageUrl); // 이미지 URL 상태 업데이트
-        setValue('image', uploadedImageUrl);
-        setPreviewImage(uploadedImageUrl); // 실제 업로드 URL로 미리보기 업데이트
-      }
-      console.log(uploadedImageUrl);
-      setUploadComplete(false);
-    }
-  }, [upLoadComplete, uploadedImageUrl, setValue]);
-
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -84,12 +72,24 @@ export default function ProfileEditModal({
       // setPreviewImage(uploadedImageUrl); // 실제 업로드 URL로 미리보기 업데이트
       console.log(uploadedImageUrl);
       setUploadedImageUrl(response);
-      setUploadComplete(true);
+      // setUploadComplete(true); // 얘떠ㅐ문임
     } catch (error) {
       console.error('이미지 업로드 에러 :', error);
       // setPreviewImage(tempPreviewUrl);
     }
   };
+
+  useEffect(() => {
+    if (upLoadComplete) {
+      if (uploadedImageUrl) {
+        setImageUrl(uploadedImageUrl); // 이미지 URL 상태 업데이트
+        setValue('image', uploadedImageUrl);
+        setPreviewImage(uploadedImageUrl); // 실제 업로드 URL로 미리보기 업데이트
+      }
+      console.log(uploadedImageUrl);
+      setUploadComplete(false);
+    }
+  }, [upLoadComplete, uploadedImageUrl, setValue]);
 
   const handleIntroduceChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value || '';

--- a/src/components/Profile/ProfileEditModal/uploadImageToS3.ts
+++ b/src/components/Profile/ProfileEditModal/uploadImageToS3.ts
@@ -1,8 +1,8 @@
 import fetchData from '@/api/fetchData';
-import GetUploadUrl from './getImageUploadUrl';
+import GetImageUploadUrl from './getImageUploadUrl';
 
 export async function uploadImageToS3(file: File) {
-  const uploadUrl = await GetUploadUrl();
+  const uploadUrl = await GetImageUploadUrl();
   if (!uploadUrl) {
     console.error('업로드 URL GET 실패');
     return null;

--- a/src/components/Profile/ProfileHeader/index.tsx
+++ b/src/components/Profile/ProfileHeader/index.tsx
@@ -6,6 +6,8 @@ import GenerationBadge from '@/components/Common/GenerationBadge';
 import Image from 'next/image';
 import { useState } from 'react';
 import FollowList from '../FollowList';
+import useFollowClick from '@/hooks/useFollowClick';
+import FollowButton from '@/components/Common/Buttons/FollowButton';
 
 export interface ProfileHeaderProps {
   memberData: MemberDataType;
@@ -24,6 +26,8 @@ export default function ProfileHeader({
     follower: false,
     following: false,
   });
+  const memberId = memberData?.memberId ?? 0;
+  const { isActive, toggleFollow } = useFollowClick(memberId);
 
   const toggleModal = (type: 'follower' | 'following') => {
     setFollowModal({
@@ -35,12 +39,11 @@ export default function ProfileHeader({
   const renderButton = () => {
     if (memberData.memberId) {
       return (
-        <button
-          type="button"
-          onClick={() => console.log('팔로잉/언팔로잉 로직 처리')}
-        >
-          팔로잉
-        </button>
+        <FollowButton
+          onClick={toggleFollow}
+          isFollowButton={true}
+          isActive={isActive}
+        />
       );
     }
     if (memberData.isAuthorized) {

--- a/src/components/Profile/ProfileHeader/index.tsx
+++ b/src/components/Profile/ProfileHeader/index.tsx
@@ -128,7 +128,7 @@ export default function ProfileHeader({
         </div>
       </div>
       <div className={cn('profile-introduce-section')}>
-        {memberData.introduce ? (
+        {memberData.introduce === '' ? (
           memberData.introduce
         ) : (
           <div className={cn('introduce-empty')}>소개가 없습니다.</div>

--- a/src/components/Profile/ProfileHeader/index.tsx
+++ b/src/components/Profile/ProfileHeader/index.tsx
@@ -41,7 +41,7 @@ export default function ProfileHeader({
       return (
         <FollowButton
           onClick={toggleFollow}
-          isFollowButton={true}
+          isFollowButton
           isActive={isActive}
         />
       );

--- a/src/hooks/useFollowClick.ts
+++ b/src/hooks/useFollowClick.ts
@@ -31,6 +31,11 @@ export default function useFollowClick(memberId: number) {
     checkFollowStatus();
   }, [memberId]);
 
+  // 팔로우 성공 후, 팔로우 상태를 다시 확인하는 함수
+  const handleSuccess = async () => {
+    await checkFollowStatus();
+  };
+
   const { mutate: addFollow } = useMutation({
     mutationFn: () =>
       fetchData({
@@ -54,11 +59,6 @@ export default function useFollowClick(memberId: number) {
       handleSuccess();
     },
   });
-
-  // 팔로우 성공 후, 팔로우 상태를 다시 확인하는 함수
-  const handleSuccess = async () => {
-    await checkFollowStatus();
-  };
 
   const toggleFollow = async () => {
     // setIsActive((prev) => !prev);

--- a/src/hooks/useFollowClick.ts
+++ b/src/hooks/useFollowClick.ts
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import fetchData from '@/api/fetchData';
 
 /**
@@ -10,28 +10,62 @@ import fetchData from '@/api/fetchData';
 
 export default function useFollowClick(memberId: number) {
   const [isActive, setIsActive] = useState(false);
+  const queryClient = useQueryClient();
+
+  interface FollowResponse {
+    isFollowed: boolean;
+  }
+
+  const checkFollowStatus = async () => {
+    try {
+      const response = (await fetchData({
+        param: `/profile/${memberId}`,
+      })) as FollowResponse;
+      setIsActive(response.isFollowed);
+    } catch (error) {
+      console.error('팔로우 상태 확인 중 오류 발생');
+    }
+  };
+
+  useEffect(() => {
+    checkFollowStatus();
+  }, [memberId]);
+
   const { mutate: addFollow } = useMutation({
     mutationFn: () =>
       fetchData({
         param: `/follow/${memberId}`,
         method: 'post',
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['followStatus', memberId] });
+      handleSuccess();
+    },
   });
+
   const { mutate: deleteFollow } = useMutation({
     mutationFn: () =>
       fetchData({
         param: `/follow/${memberId}`,
         method: 'delete',
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['followStatus', memberId] });
+      handleSuccess();
+    },
   });
 
-  const toggleFollow = async () => {
-    setIsActive((prev) => !prev);
+  // 팔로우 성공 후, 팔로우 상태를 다시 확인하는 함수
+  const handleSuccess = async () => {
+    await checkFollowStatus();
+  };
 
+  const toggleFollow = async () => {
+    // setIsActive((prev) => !prev);
     if (!isActive) {
-      await addFollow();
+      addFollow();
     } else {
-      await deleteFollow();
+      deleteFollow();
     }
   };
 

--- a/src/pages/profile/index.page.tsx
+++ b/src/pages/profile/index.page.tsx
@@ -6,19 +6,13 @@ import classNames from 'classnames/bind';
 import styles from './MemberDataContainer.module.scss';
 import ContentContainer from '@/components/Common/ContentContainer';
 import { ContainerOptionType } from '@/@types/type';
-import FeedList from '@/components/Feed/FeedList';
-import PostList from '@/components/Post/PostList';
 import ScrapList from '@/components/Common/ScrapList';
 import { fetchMemberData } from './api';
 import { GetServerSideProps } from 'next';
 import { FeedDetailType } from '@/components/Feed/types';
 import MyFeedList from '@/components/Profile/MyFeedList';
 // import MyPostList from '@/components/Profile/MyPostList';
-import {
-  PostInfoType,
-  PostListDataType,
-  PostListType,
-} from '@/components/Post/types';
+import { PostListType } from '@/components/Post/types';
 
 import { SortType } from '@/constants/sortType';
 import MyPostList from '@/components/Profile/MyPostList';


### PR DESCRIPTION
<!--타이틀은 아래처럼 적어주세요
ex) [Feat] 로그인 기능 추가
    [Fix] 로그인이 안되는 문제 수정-->

## 📃 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- 

## 💬 무슨 이유로 코드를 변경했는지
- 프로필 이미지를 수정하면 깜빡이다가 없어지는 현상을 해결했습니다. 
- 수정 완료 시 리렌더링 됩니다. 
- 팔로잉 상태에 따라 팔로잉 버튼이 동작하게 수정했습니다.  
- 소개가 없을 때 빈 값이 들어가서 '소개가 없습니다' 가 표시되게 수정했습니다. 

## ❗ 어떤 위험이나 장애가 발견되었는지
-  '팔로잉' : 회색 / '팔로우' : 보라색 이어야 하는데, 지금은 둘 다 회색으로 나옵니다.... 
이상한 점은, '팔로잉' : 보라색 / '팔로우' : 회색 으로 설정하면 컬러까지 토글이 잘 됩니다. 대체 왜그러는지 한번만 봐주시면 너무 감사하겠습니다.
바꾼건 컬러값밖에 없는데 서로 컬러값을 바꾸기만해도 컬러 토글이 잘되고 반대로 하면 안되니까 이유를 못찾겠어용..

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
 

## ✅ 테스트 계획 또는 완료 사항
- 프로필 이미지 삭제
- 관리자 페이지 틀을 만들었습니다. api가 나오면 붙여볼 예정입니다...!! 아직 코드만 짜놓다보니 그냥 오류나는 페이지라서 PR은 아직 올리지 않았습니다. 

## 🖼️ 관련 스크린샷
-
