### PR TITLE
[Feat] 해시태그 및 제목 글자 수 제한, 빌드오류 수정

### DIFF
--- a/src/components/Post/HashTag/HashTagInput.tsx
+++ b/src/components/Post/HashTag/HashTagInput.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import HashTag from '.';
 import styles from './HashTagInput.module.scss';
 import HashTagRecommend from './HashTagRecommend';
+import { useToast } from '@/hooks/useToast';
 
 interface HashTagInputProps {
   hashtags: HashTagType[];
@@ -20,6 +21,7 @@ export default function HashTagInput({
   setHashtags,
 }: HashTagInputProps) {
   const [tagValue, setTagValue] = useState<string>('');
+  const { showToastHandler } = useToast();
 
   const { data, isSuccess } = useQuery<HashTagType[]>({
     queryKey: ['hashtag', tagValue],
@@ -77,7 +79,12 @@ export default function HashTagInput({
   };
 
   const handleSearchHashtag = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.value.length > 15) {
+      showToastHandler('15자 이상 작성할 수 없습니다.', 'warn');
+      return '';
+    }
     setTagValue(event.target.value);
+    return '';
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/Post/Markdown/index.tsx
+++ b/src/components/Post/Markdown/index.tsx
@@ -62,7 +62,7 @@ export default function MarkdownContent({
           src={currentImageUrl}
           alt="detail"
           style={{
-            'object-fit': 'contain',
+            objectFit: 'contain',
             width: '800px',
             maxHeight: '80vh',
             maxWidth: '80vw',

--- a/src/components/Post/MarkdownEditor/index.tsx
+++ b/src/components/Post/MarkdownEditor/index.tsx
@@ -34,7 +34,7 @@ export default function MarkdownEditor({
 }: MarkdownEditorProps) {
   const [previewUrl, setPreviewUrl] = useState('');
   const [isPreviewClicked, setIsPreviewClicked] = useState(false);
-  const [isWriteClicked, setIsWriteClicked] = useState(false);
+  const [isWriteClicked, setIsWriteClicked] = useState(true);
 
   const imageRef = useRef<HTMLInputElement>(null);
 

--- a/src/components/Post/PostEditor/index.tsx
+++ b/src/components/Post/PostEditor/index.tsx
@@ -1,7 +1,7 @@
 import fetchData from '@/api/fetchData';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import CategoryList from '../CategoryList';
 import HashTagInput from '../HashTag/HashTagInput';
 import MarkdownEditor from '../MarkdownEditor';
@@ -9,6 +9,7 @@ import { PostDetailType, PostRequestType } from '../types';
 import styles from './PostEditor.module.scss';
 import { CATEGORY_LIST } from '@/constants/categoryList';
 import getKeyByValue from '@/utils/getKeyByValue';
+import { useToast } from '@/hooks/useToast';
 
 interface PostEditorProps {
   postId: string;
@@ -23,6 +24,7 @@ export default function PostEditor({
   postData,
   mergeState,
 }: PostEditorProps) {
+  const { showToastHandler } = useToast();
   const [selectedCategory, setSelectedCategory] = useState('NOTICE');
 
   const { data, isSuccess } = useQuery<PostDetailType>({
@@ -33,6 +35,15 @@ export default function PostEditor({
       }),
     enabled: !!postId,
   });
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.value.length > 50) {
+      showToastHandler('50자 이상 작성할 수 없습니다.', 'warn');
+      return '';
+    }
+    mergeState({ title: event.target.value });
+    return '';
+  };
 
   useEffect(() => {
     if (postId && isSuccess) {
@@ -68,7 +79,7 @@ export default function PostEditor({
         <input
           className={cn('title', 'input')}
           value={postData.title}
-          onChange={(event) => mergeState({ title: event.target.value })}
+          onChange={handleTitleChange}
           placeholder="제목을 입력하세요"
         />
         <MarkdownEditor

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -3,7 +3,7 @@ import { showToast } from '@/redux/toastSlice';
 
 /**
  * @param {string} text - text 속성은 토스트에 표시할 텍스트
- * @param { React.ReactNode} icon - icon 속성은 토스트에 표시할 아이콘
+ * @param { React.ReactNode} type - 토스트에 표시할 아이콘에 따라 'check' | 'warn' 두 가지 타입을 가짐
  * @returns {function} showToastHandler - 토스트를 보여주는 함수
  * @example
  * const { showToastHandler } = useToast();
@@ -12,7 +12,7 @@ import { showToast } from '@/redux/toastSlice';
 
 export const useToast = () => {
   const dispatch = useDispatch();
-  const showToastHandler = (text: string, type: string) => {
+  const showToastHandler = (text: string, type: 'check' | 'warn') => {
     dispatch(
       showToast({
         text,


### PR DESCRIPTION
 

## 💬 무슨 이유로 코드를 변경했는지
- 해시태그 하나 당 15자, 제목 50자로 제한하고 넘을 시 입력 막고 토스트 뜨도록 수정했습니다
- 방금 머지한거에 빌드오류 있어서 짧게 하고 올립니다 ㅎㅎ.. 조ㅑ송합니다

## ❗ 어떤 위험이나 장애가 발견되었는지
- 

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  

## ✅ 테스트 계획 또는 완료 사항
-

## 🖼️ 관련 스크린샷
-
<img width="500" alt="image" src="https://github.com/project-cosmo-sns/cosmos/assets/127701092/8e055b8c-f0d8-4822-a9e6-1c041d8bcebf">
