### PR TITLE
[Feat] 피드 댓글 리패치, 피드 댓글 무한스크롤

### DIFF
--- a/src/components/Common/CommentInput/CommentInput.module.scss
+++ b/src/components/Common/CommentInput/CommentInput.module.scss
@@ -3,4 +3,24 @@
   justify-content: center;
   width: 100%;
   gap: 8px;
+
+  .textarea-wrapper {
+    width: 100%;
+
+    .textarea {
+      border: none;
+      width: 100%;
+      height: 48px;
+      line-height: 135%;
+      resize: none;
+      font-size: 1.6rem;
+      border-radius: 5px;
+      padding: 15px 16px;
+      @include color($black-03, $white-01);
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+  }
 }

--- a/src/components/Common/CommentInput/index.tsx
+++ b/src/components/Common/CommentInput/index.tsx
@@ -4,7 +4,11 @@ import DefaultButton from '../Buttons/DefaultButton';
 import styles from './CommentInput.module.scss';
 // eslint-disable-next-line import/no-cycle
 import { useCommentRequest } from '@/hooks/useCommentRequest';
-import { QueryObserverResult, RefetchOptions } from '@tanstack/react-query';
+import {
+  InfiniteData,
+  QueryObserverResult,
+  RefetchOptions,
+} from '@tanstack/react-query';
 import { CommentListType } from '@/components/Feed/types';
 
 export interface Comment {
@@ -13,18 +17,22 @@ export interface Comment {
 
 interface CommentInputTypes {
   placeholder: string;
-  feedId: number;
+  postId: number;
+  isFeed: boolean;
   refetch: (
     options?: RefetchOptions | undefined,
-  ) => Promise<QueryObserverResult<CommentListType, Error>>;
+  ) => Promise<
+    QueryObserverResult<InfiniteData<CommentListType, unknown>, Error>
+  >;
 }
 
 const cn = classNames.bind(styles);
 
 export default function CommentInput({
   placeholder,
-  feedId,
+  postId,
   refetch,
+  isFeed,
 }: CommentInputTypes) {
   const {
     register,
@@ -37,7 +45,7 @@ export default function CommentInput({
     },
   });
 
-  const { postCommentMutate } = useCommentRequest(feedId, true, refetch);
+  const { postCommentMutate } = useCommentRequest(postId, isFeed, refetch);
 
   const onSubmit = async (data: Comment) => {
     postCommentMutate(data);

--- a/src/components/Common/CommentInput/index.tsx
+++ b/src/components/Common/CommentInput/index.tsx
@@ -22,6 +22,7 @@ export default function CommentInput({
   const {
     register,
     handleSubmit,
+    reset,
     formState: { isSubmitting },
   } = useForm<Comment>({
     defaultValues: {

--- a/src/components/Common/CommentInput/index.tsx
+++ b/src/components/Common/CommentInput/index.tsx
@@ -1,8 +1,11 @@
 import classNames from 'classnames/bind';
 import { useForm } from 'react-hook-form';
 import DefaultButton from '../Buttons/DefaultButton';
-import TextArea from '../Input/Textarea';
 import styles from './CommentInput.module.scss';
+// eslint-disable-next-line import/no-cycle
+import { useCommentRequest } from '@/hooks/useCommentRequest';
+import { QueryObserverResult, RefetchOptions } from '@tanstack/react-query';
+import { CommentListType } from '@/components/Feed/types';
 
 export interface Comment {
   comment: string;
@@ -10,14 +13,18 @@ export interface Comment {
 
 interface CommentInputTypes {
   placeholder: string;
-  onSubmit: (data: Comment) => void;
+  feedId: number;
+  refetch: (
+    options?: RefetchOptions | undefined,
+  ) => Promise<QueryObserverResult<CommentListType, Error>>;
 }
 
 const cn = classNames.bind(styles);
 
 export default function CommentInput({
   placeholder,
-  onSubmit,
+  feedId,
+  refetch,
 }: CommentInputTypes) {
   const {
     register,
@@ -30,14 +37,22 @@ export default function CommentInput({
     },
   });
 
+  const { postCommentMutate } = useCommentRequest(feedId, true, refetch);
+
+  const onSubmit = async (data: Comment) => {
+    postCommentMutate(data);
+    reset();
+  };
+
   return (
     <form className={cn('wrapper')} onSubmit={handleSubmit(onSubmit)}>
-      <TextArea
-        placeholder={placeholder}
-        register={{
-          ...register('comment', { required: true, maxLength: 300 }),
-        }}
-      />
+      <div className={cn('textarea-wrapper')}>
+        <textarea
+          className={cn('textarea')}
+          placeholder={placeholder}
+          {...register('comment', { required: true, maxLength: 300 })}
+        />
+      </div>
       <DefaultButton
         disabled={isSubmitting}
         buttonType="submit"

--- a/src/components/Common/Layout/Modal/index.tsx
+++ b/src/components/Common/Layout/Modal/index.tsx
@@ -44,10 +44,10 @@ export default function Modal({
     toggleModal && toggleModal(!modalVisible);
   };
 
-  useOutSideClick({
-    ref: modalRef,
-    callback: handleCloseModal,
-  });
+  // useOutSideClick({
+  //   ref: modalRef,
+  //   callback: handleCloseModal,
+  // });
 
   return (
     <div className="Modal">

--- a/src/components/Feed/FeedDetails/FeedDetails.module.scss
+++ b/src/components/Feed/FeedDetails/FeedDetails.module.scss
@@ -5,21 +5,28 @@
   width: 100%;
 }
 
-.comment-list {
-  padding-bottom: 20px;
-  border-style: solid;
-  border-image: linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0.15) 0%,
-    rgba(255, 255, 255, 0.05) 100%
-  );
-  border-image-slice: 1;
-  border-image-width: 0 0 1px 0;
-  margin-bottom: 20px;
+.comment-list-area {
+  max-height: 350px;
+  overflow: scroll;
+  scrollbar-width: none;
+  border-radius: 5px;
 
-  &:last-child {
-    border: none;
-    padding-bottom: 0px;
+  .comment-list {
+    padding-bottom: 20px;
+    border-style: solid;
+    border-image: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.15) 0%,
+      rgba(255, 255, 255, 0.05) 100%
+    );
+    border-image-slice: 1;
+    border-image-width: 0 0 1px 0;
+    margin-bottom: 20px;
+
+    &:last-child {
+      border: none;
+      padding-bottom: 0px;
+    }
   }
 }
 

--- a/src/components/Feed/FeedDetails/index.tsx
+++ b/src/components/Feed/FeedDetails/index.tsx
@@ -45,12 +45,11 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
   });
 
   const {
-    onSubmit,
     deleteCommentRequest,
     postLikeRequest,
     deleteLikeRequest,
     editCommentRequest,
-  } = useCommentRequest(feedId, true, commentRefetch);
+  } = useCommentRequest(feedId, true);
 
   const feed: FeedDetailType = feedData ?? {
     writer: {
@@ -94,7 +93,11 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
             editState={isEdit}
             toggleEditMode={setIsEdit}
           />
-          <CommentInput placeholder="댓글을 입력하세요" onSubmit={onSubmit} />
+          <CommentInput
+            placeholder="댓글을 입력하세요"
+            feedId={feedId}
+            refetch={commentRefetch}
+          />
           <div className={cn('comment-list-area')}>
             {commentList.length ? (
               commentList.map((comment) => (

--- a/src/components/Feed/FeedDetails/index.tsx
+++ b/src/components/Feed/FeedDetails/index.tsx
@@ -17,19 +17,12 @@ import styles from './FeedDetails.module.scss';
 export default function FeedDetails({ feedId }: { feedId: number }) {
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const cn = classNames.bind(styles);
-  const {
-    onSubmit,
-    deleteCommentRequest,
-    postLikeRequest,
-    deleteLikeRequest,
-    editCommentRequest,
-  } = useCommentRequest(feedId, true);
 
   const {
     data: feedData,
     isPending: isFeedDataPending,
     isError: isFeedDataError,
-    refetch,
+    refetch: feedRefetch,
   } = useQuery({
     queryKey: ['feedDetails', feedId],
     queryFn: ({ queryKey }) =>
@@ -40,6 +33,7 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
 
   const {
     data: commentListData,
+    refetch: commentRefetch,
     isPending: isCommentDataPending,
     isError: isCommentDataError,
   } = useQuery({
@@ -49,6 +43,14 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
         param: `feed/${queryKey[1]}/comment/list`,
       }),
   });
+
+  const {
+    onSubmit,
+    deleteCommentRequest,
+    postLikeRequest,
+    deleteLikeRequest,
+    editCommentRequest,
+  } = useCommentRequest(feedId, true, commentRefetch);
 
   const feed: FeedDetailType = feedData ?? {
     writer: {
@@ -86,7 +88,6 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
       ) : (
         <div className={cn('container')}>
           <FeedCard
-            refetch={refetch}
             feedData={feed}
             hasPadding={false}
             forDetails
@@ -94,7 +95,7 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
             toggleEditMode={setIsEdit}
           />
           <CommentInput placeholder="댓글을 입력하세요" onSubmit={onSubmit} />
-          <div>
+          <div className={cn('comment-list-area')}>
             {commentList.length ? (
               commentList.map((comment) => (
                 <div key={comment.comment.id} className={cn('comment-list')}>

--- a/src/components/Feed/FeedDetails/index.tsx
+++ b/src/components/Feed/FeedDetails/index.tsx
@@ -9,6 +9,7 @@ import { useCommentRequest } from '@/hooks/useCommentRequest';
 import EditFeed from '@/components/Feed/EditFeed/index';
 import { FeedDetailType, CommentDetailType, CommentListType } from '../types';
 import styles from './FeedDetails.module.scss';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 
 /**
  * @return {JSX.Element} FeedDetails - 추후에 변경 예정입니다. 피드 리스트에서 특정 피드를 클릭한다면 클리한 피드의 아이디를 통해 데이터를 요청해 화면에 보여줍니다.
@@ -36,12 +37,17 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
     refetch: commentRefetch,
     isPending: isCommentDataPending,
     isError: isCommentDataError,
-  } = useQuery({
+    isFetchingNextPage,
+    ref,
+  } = useInfiniteScroll<CommentListType>({
     queryKey: ['feedComments', feedId],
-    queryFn: ({ queryKey }) =>
-      fetchData<CommentListType>({
-        param: `feed/${queryKey[1]}/comment/list`,
+    fetchFunction: (page: number) =>
+      fetchData({
+        param: `feed/${feedId}/comment/list?order=DESC&page=${page}&take=10`,
       }),
+    getNextPageParam: (lastPage) => {
+      return lastPage.meta.hasNextPage ? lastPage.meta.page + 1 : undefined;
+    },
   });
 
   const {
@@ -70,7 +76,7 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
       emojis: [],
     },
   };
-  const commentList: CommentDetailType[] = commentListData?.data ?? [];
+
   if (isFeedDataPending) return '피드 데이터 불러오는 중...';
   if (isFeedDataError) return '피드 데이터 에러 발생!';
   if (isCommentDataPending) return '코멘트 데이터 불러오는 중...';
@@ -95,30 +101,35 @@ export default function FeedDetails({ feedId }: { feedId: number }) {
           />
           <CommentInput
             placeholder="댓글을 입력하세요"
-            feedId={feedId}
+            postId={feedId}
             refetch={commentRefetch}
+            isFeed
           />
           <div className={cn('comment-list-area')}>
-            {commentList.length ? (
-              commentList.map((comment) => (
-                <div key={comment.comment.id} className={cn('comment-list')}>
-                  <CommentCard
-                    comment={comment}
-                    deleteLikeRequest={deleteLikeRequest}
-                    postLikeRequest={postLikeRequest}
-                    deleteCommentRequest={deleteCommentRequest}
-                    editCommentRequest={editCommentRequest}
-                  />
+            {commentListData?.pages.map(({ data: commentList }, index) =>
+              commentList.length ? (
+                commentList.map((comment) => (
+                  <div key={comment.comment.id} className={cn('comment-list')}>
+                    <CommentCard
+                      comment={comment}
+                      deleteLikeRequest={deleteLikeRequest}
+                      postLikeRequest={postLikeRequest}
+                      deleteCommentRequest={deleteCommentRequest}
+                      editCommentRequest={editCommentRequest}
+                    />
+                  </div>
+                ))
+              ) : (
+                <div key={index} className={cn('empty-comment')}>
+                  <span className={cn('message')}>
+                    😭 {feed.writer.nickname} 님에게 남겨진 댓글이 아직 없어요.
+                    😭
+                  </span>
                 </div>
-              ))
-            ) : (
-              <div className={cn('empty-comment')}>
-                <span className={cn('message')}>
-                  😭 {feed.writer.nickname} 님에게 남겨진 댓글이 아직 없어요. 😭
-                </span>
-              </div>
+              ),
             )}
           </div>
+          {!isFetchingNextPage && <div ref={ref} />}
         </div>
       )}
     </>

--- a/src/components/Feed/FeedList/index.tsx
+++ b/src/components/Feed/FeedList/index.tsx
@@ -27,6 +27,7 @@ export default function FeedList({ feedList }: FeedListProps) {
     data: feedListData,
     ref,
     isFetchingNextPage,
+    refetch,
   } = useInfiniteScroll<FeedListType>({
     queryKey: ['feedList'],
     fetchFunction: (pageParam) =>
@@ -43,6 +44,7 @@ export default function FeedList({ feedList }: FeedListProps) {
         {feedPages.map((feedPage) =>
           feedPage.data.map((feed) => (
             <FeedCard
+              refetch={refetch}
               key={feed.feed.id}
               feedData={feed}
               hasPadding

--- a/src/components/Post/PostComment/PostComment.module.scss
+++ b/src/components/Post/PostComment/PostComment.module.scss
@@ -9,6 +9,10 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-height: 350px;
+  overflow: scroll;
+  scrollbar-width: none;
+  border-radius: 5px;
 }
 
 .comment-list {

--- a/src/components/Post/PostComment/index.tsx
+++ b/src/components/Post/PostComment/index.tsx
@@ -15,7 +15,6 @@ const cn = classNames.bind(styles);
 
 export default function PostComment({ postId }: PostCommentProps) {
   const {
-    onSubmit,
     deleteCommentRequest,
     postLikeRequest,
     deleteLikeRequest,
@@ -27,6 +26,7 @@ export default function PostComment({ postId }: PostCommentProps) {
     ref,
     isFetchingNextPage,
     isPending,
+    refetch,
   } = useInfiniteScroll<CommentListType>({
     queryKey: ['commentList', postId],
     fetchFunction: (page: number) =>
@@ -42,7 +42,12 @@ export default function PostComment({ postId }: PostCommentProps) {
 
   return (
     <div className={cn('wrapper')}>
-      <CommentInput placeholder="댓글을 입력하세요" onSubmit={onSubmit} />
+      <CommentInput
+        placeholder="댓글을 입력하세요"
+        postId={postId}
+        refetch={refetch}
+        isFeed={false}
+      />
       <div className={cn('comment-container')}>
         {commentData?.pages.map(({ data: commentList }, index) =>
           commentList.length ? (

--- a/src/hooks/useCommentRequest.ts
+++ b/src/hooks/useCommentRequest.ts
@@ -3,6 +3,7 @@ import { PostCommentType } from '@/components/Common/CommentInput/api';
 import { Comment } from '@/components/Common/CommentInput';
 import { EditCommentType } from '@/@types/type';
 import {
+  InfiniteData,
   QueryObserverResult,
   RefetchOptions,
   useMutation,
@@ -15,7 +16,9 @@ export function useCommentRequest(
   forFeeds: boolean,
   refetch?: (
     options?: RefetchOptions | undefined,
-  ) => Promise<QueryObserverResult<CommentListType, Error>>,
+  ) => Promise<
+    QueryObserverResult<InfiniteData<CommentListType, unknown>, Error>
+  >,
 ) {
   const { mutate: postCommentMutate } = useMutation({
     mutationFn: (dataParam: Comment) =>

--- a/src/hooks/useCommentRequest.ts
+++ b/src/hooks/useCommentRequest.ts
@@ -1,10 +1,21 @@
 import { PostCommentType } from '@/components/Common/CommentInput/api';
 import { Comment } from '@/components/Common/CommentInput';
 import { EditCommentType } from '@/@types/type';
-import { useMutation } from '@tanstack/react-query';
+import {
+  QueryObserverResult,
+  RefetchOptions,
+  useMutation,
+} from '@tanstack/react-query';
 import fetchData from '@/api/fetchData';
+import { CommentListType } from '@/components/Feed/types';
 
-export function useCommentRequest(postId: number, forFeeds: boolean) {
+export function useCommentRequest(
+  postId: number,
+  forFeeds: boolean,
+  refetch: (
+    options?: RefetchOptions | undefined,
+  ) => Promise<QueryObserverResult<CommentListType, Error>>,
+) {
   const { mutate: postCommentMutate } = useMutation({
     mutationFn: (dataParam: Comment) =>
       fetchData<PostCommentType>({
@@ -14,6 +25,11 @@ export function useCommentRequest(postId: number, forFeeds: boolean) {
           content: dataParam.comment,
         },
       }),
+    onSuccess: () => {
+      if (refetch) {
+        refetch();
+      }
+    },
   });
 
   const onSubmit = (data: Comment) => {

--- a/src/hooks/useCommentRequest.ts
+++ b/src/hooks/useCommentRequest.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 import { PostCommentType } from '@/components/Common/CommentInput/api';
 import { Comment } from '@/components/Common/CommentInput';
 import { EditCommentType } from '@/@types/type';
@@ -12,7 +13,7 @@ import { CommentListType } from '@/components/Feed/types';
 export function useCommentRequest(
   postId: number,
   forFeeds: boolean,
-  refetch: (
+  refetch?: (
     options?: RefetchOptions | undefined,
   ) => Promise<QueryObserverResult<CommentListType, Error>>,
 ) {
@@ -25,16 +26,12 @@ export function useCommentRequest(
           content: dataParam.comment,
         },
       }),
-    onSuccess: () => {
+    onSuccess: async () => {
       if (refetch) {
-        refetch();
+        await refetch();
       }
     },
   });
-
-  const onSubmit = (data: Comment) => {
-    postCommentMutate(data);
-  };
 
   const { mutate: deleteCommentMutate } = useMutation({
     mutationFn: (commentId: number) =>
@@ -100,7 +97,7 @@ export function useCommentRequest(
   };
 
   return {
-    onSubmit,
+    postCommentMutate,
     deleteCommentRequest,
     postLikeRequest,
     deleteLikeRequest,


### PR DESCRIPTION
## 📃 관련 이슈
- #47 

## 💬 무슨 이유로 코드를 변경했는지

- 피드 댓글 리패치를 위해서 CommentInput 컴포넌트를 수정했습니다

- 기존에는 onSubmit을 프롭스로 받았지만 useCommentRequest 커스텀 훅을 피드, 포스트 공통으로 사용할 수 있게 만들어서 컴포넌트 안에서 onSubmit 함수를 정의했습니다. ( + textArea value reset을 위해 )

- 댓글 무한스크롤 구현을 안했더라구요.... 후딱 했습니다 

- 컴포넌트 변경이 생겨서 포스트 쪽에도 오류가 발생해 수정해뒀습니다

- 포스트 댓글 영역 350px 로 수정했습니다 css 높이 한번 봐보시고 수정해야겠다 싶으면 말씀부탁드려요

## ❗ 어떤 위험이나 장애가 발견되었는지
- 빌드 과정에서 ./src/components/Profile/FollowList/Follow/index.tsx:58:11 오류 나고 있으니 수정부탁드립니당

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  

## ✅ 테스트 계획 또는 완료 사항
-

## 🖼️ 관련 스크린샷
- 


