### PR TITLE
[Fix] 알림 피드인경우 모달이 안열림 & 라우팅 이상함 문제 해결

### DIFF
--- a/src/components/Common/Layout/Notification/NotificationItem/index.tsx
+++ b/src/components/Common/Layout/Notification/NotificationItem/index.tsx
@@ -16,13 +16,9 @@ const cn = classNames.bind(styles);
 
 type NotificationItemProps = {
   data: NotificationData;
-  onClose: () => void;
 };
 
-export default function NotificationItem({
-  data,
-  onClose,
-}: NotificationItemProps) {
+export default function NotificationItem({ data }: NotificationItemProps) {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -73,7 +69,6 @@ export default function NotificationItem({
       type === notificationType.CREATE_FEED_EMOJI
     ) {
       setIsModalOpen(true);
-      // console.log(feedId);
     }
   };
 

--- a/src/components/Common/Layout/Notification/NotificationItem/index.tsx
+++ b/src/components/Common/Layout/Notification/NotificationItem/index.tsx
@@ -63,19 +63,18 @@ export default function NotificationItem({
 
     if (
       type === notificationType.CREATE_POST_COMMENT ||
-      notificationType.CREATE_POST_EMOJI
+      type === notificationType.CREATE_POST_EMOJI
     ) {
       router.push(`/post/${postId}`);
     }
 
     if (
       type === notificationType.CREATE_FEED_COMMENT ||
-      notificationType.CREATE_FEED_EMOJI
+      type === notificationType.CREATE_FEED_EMOJI
     ) {
       setIsModalOpen(true);
+      // console.log(feedId);
     }
-
-    onClose();
   };
 
   const formattedCreatedAt = getElapsedTime(createdAt);
@@ -120,14 +119,14 @@ export default function NotificationItem({
           <span className={cn('notification-dot')} />
         )}
       </div>
-      {type === notificationType.CREATE_FEED_COMMENT && isModalOpen && (
+      {isModalOpen && feedId && (
         <Modal
           toggleModal={() => setIsModalOpen(false)}
           modalVisible={isModalOpen}
           cssModalSize={cn('feed-detail-modalSize')}
           cssComponentDisplay={cn('feed-detail-componentDisplay')}
         >
-          <FeedDetails feedId={feedId!} />
+          <FeedDetails feedId={feedId} />
         </Modal>
       )}
     </>


### PR DESCRIPTION
## 💬 무슨 이유로 코드를 변경했는지
- 알림 피드인경우 모달 열림 수정
- 라우팅 이상해서 수정- 

## ❗ 어떤 위험이나 장애가 발견되었는지
- 하.... onClose때문에 피드가 안열린거였어서 일단은 알림 클릭한 뒤 팝오버 닫히는건 임시 삭제했습니다. 어떻게 해야할지 생각좀해보겠습니다

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  다른건 모르겠으나...!! 여러분, 인증 상태를 역시 전역으로 빼는게 어떤지 제안드립니다👀 ㅠㅠ 일부에만 들어가는 컴포넌트에 인증이 필요한거면 잘 모르겠는데 검색, 알림의 경우 레이아웃에 포함된거다 보니까 처리가 애매해지네요.............

## ✅ 테스트 계획 또는 완료 사항
- 일단.... 알림, 검색 미인증인 경우 팅겨내기 작업?
- 모달 관련.......? 
