### PR TITLE
[Feat] 내 프로필에서 스크랩한 목록 불러오기

### DIFF
--- a/src/components/Common/CommentCard/EditComment.tsx
+++ b/src/components/Common/CommentCard/EditComment.tsx
@@ -41,7 +41,7 @@ export default function EditComment({
           </span>
         )}
       </div>
-      <DefaultButton buttonType="submit" size="small" color="purple">
+      <DefaultButton buttonType="submit" size="small" color="black-01">
         수정
       </DefaultButton>
     </form>

--- a/src/components/Common/CommentCard/index.tsx
+++ b/src/components/Common/CommentCard/index.tsx
@@ -6,11 +6,11 @@ import { useState } from 'react';
 import ActionButtons from '../Buttons/ActionButtons';
 import DeleteModal from '../DeleteModal';
 import { LikeIcon, LikedIcon } from '../IconCollection';
+import ReplyContainer from '../ReplyContainer';
 import TextWithLinks from '../TextWithLinks';
 import WriterProfile from '../WriterProfile';
 import styles from './CommentCard.module.scss';
 import EditComment from './EditComment';
-import ReplyContainer from '../ReplyContainer';
 
 const cn = classNames.bind(styles);
 
@@ -52,6 +52,7 @@ export default function CommentCard({
     isHearted,
     createdAt,
     isMine,
+    isReplied,
   } = commentData;
 
   const [isCommentEditing, setIsCommentEditing] = useState(false);

--- a/src/components/Common/ContentContainer/ContentContainer.module.scss
+++ b/src/components/Common/ContentContainer/ContentContainer.module.scss
@@ -7,9 +7,17 @@
   height: 56px;
   border-radius: 50%;
   background-color: $glass-02;
+  backdrop-filter: blur(10px);
 
   @include flex-arrange;
   cursor: pointer;
+
+  &:hover {
+    background-color: $primary-01;
+    transform: scale(1.1);
+    transition-property: transform, background-color;
+    transition-duration: 0.2s;
+  }
 }
 
 .wrapper {

--- a/src/components/Common/ScrapList/index.tsx
+++ b/src/components/Common/ScrapList/index.tsx
@@ -1,3 +1,0 @@
-export default function ScrapList() {
-  return <div>스크랩리스트입니당</div>;
-}

--- a/src/components/Feed/types.ts
+++ b/src/components/Feed/types.ts
@@ -36,6 +36,7 @@ export interface Comment {
   createdAt: string;
   isHearted: boolean;
   isMine: boolean;
+  isReplied?: boolean;
 }
 
 export interface CommentDetailType {

--- a/src/components/Post/ScrapButton/index.tsx
+++ b/src/components/Post/ScrapButton/index.tsx
@@ -25,7 +25,6 @@ export default function ScrapButton({
         width="24"
         height="24"
         viewBox="0 0 24 24"
-        // 스크랩 시 임시로 색상 설정. 추후 색상 변경 예정
         fill={isClicked ? '#A0A5BB' : 'none'}
         onClick={() => {
           setIsClicked(!isClicked);

--- a/src/components/Profile/MyPostList/MyPostList.module.scss
+++ b/src/components/Profile/MyPostList/MyPostList.module.scss
@@ -33,7 +33,6 @@
 
   .post-container {
     // padding: 0 24px 12px;
-
-    gap: 12px;
+    gap: 0;
   }
 }

--- a/src/components/Profile/MyPostList/index.tsx
+++ b/src/components/Profile/MyPostList/index.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect } from 'react';
-import classNames from 'classnames/bind';
-import { PostListType } from '@/components/Post/types';
-import styles from './MyPostList.module.scss';
-import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import fetchData from '@/api/fetchData';
 import PostListContent from '@/components/Post/PostList/PostListContent';
+import { PostListType } from '@/components/Post/types';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { MemberDataType } from '@/pages/profile/types';
+import classNames from 'classnames/bind';
+import { useEffect } from 'react';
+import styles from './MyPostList.module.scss';
 
 interface PostListProps {
   postList: PostListType;

--- a/src/components/Profile/MyScrapList/api.ts
+++ b/src/components/Profile/MyScrapList/api.ts
@@ -1,0 +1,20 @@
+import instance from '@/api/axios';
+import { PostListType } from '@/components/Post/types';
+import { GetServerSidePropsContext } from 'next/types';
+
+export default async function getMyScrapList(
+  context: GetServerSidePropsContext,
+) {
+  const { req } = context;
+  const cookies = req.headers.cookie || '';
+
+  const endpoint = '/profile/mine/scrap';
+
+  const scrapData: PostListType = await instance.get(endpoint, {
+    headers: {
+      Cookie: cookies,
+    },
+    // withCredentials: true,
+  });
+  return scrapData;
+}

--- a/src/components/Profile/MyScrapList/index.tsx
+++ b/src/components/Profile/MyScrapList/index.tsx
@@ -1,0 +1,46 @@
+import fetchData from '@/api/fetchData';
+import PostListContent from '@/components/Post/PostList/PostListContent';
+import { PostListType } from '@/components/Post/types';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import classNames from 'classnames/bind';
+import styles from '../MyPostList/MyPostList.module.scss';
+
+interface MyScrapListProps {
+  scrapList: PostListType;
+}
+
+const cn = classNames.bind(styles);
+
+export default function MyScrapList({ scrapList }: MyScrapListProps) {
+  const {
+    data: scrapListData,
+    ref,
+    isFetchingNextPage,
+    isPending,
+  } = useInfiniteScroll<PostListType>({
+    queryKey: ['scrapList'],
+    fetchFunction: (pageParam) =>
+      fetchData({
+        param: `/profile/mine/scrap?order=DESC&page=${pageParam}&take=10`,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.meta.hasNextPage ? lastPage.meta.page + 1 : undefined,
+  });
+
+  const scrapDataList = scrapListData?.pages ?? [];
+
+  return (
+    <div className={cn('wrapper')}>
+      <div className={cn('post-container')}>
+        {isPending ? (
+          <PostListContent postDataList={scrapList} />
+        ) : (
+          scrapDataList.map((scrap) => (
+            <PostListContent key={scrap.meta.page} postDataList={scrap} />
+          ))
+        )}
+        {!isFetchingNextPage && <div ref={ref} />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Profile/ProfileContent/EmptyContent.module.scss
+++ b/src/components/Profile/ProfileContent/EmptyContent.module.scss
@@ -7,3 +7,10 @@
   font-size: 1.6rem;
   font-weight: 500;
 }
+
+.no-post {
+  @include flex-arrange;
+  width: 100%;
+  height: 540px;
+  color: $white-01;
+}

--- a/src/components/Profile/ProfileContent/ProfileContent.tsx
+++ b/src/components/Profile/ProfileContent/ProfileContent.tsx
@@ -1,21 +1,28 @@
-import ScrapList from '@/components/Common/ScrapList';
-import MyFeedList from '../MyFeedList';
-import MyPostList from '../MyPostList';
 import { ContainerOptionType } from '@/@types/type';
-import { FeedDetailType, FeedListType } from '@/components/Feed/types';
+import { FeedListType } from '@/components/Feed/types';
 import { PostListType } from '@/components/Post/types';
 import { MemberDataType } from '@/pages/profile/types';
+import MyFeedList from '../MyFeedList';
+import MyPostList from '../MyPostList';
+import MyScrapList from '../MyScrapList';
+import classNames from 'classnames/bind';
+import styles from './EmptyContent.module.scss';
 
 interface ProfileContentProps {
   selectedOption: ContainerOptionType;
   myFeedList: FeedListType;
   myPostList: PostListType;
+  myScrapList: PostListType;
   memberData: MemberDataType;
 }
+
+const cn = classNames.bind(styles);
+
 export default function ProfileContent({
   selectedOption,
   myFeedList,
   myPostList,
+  myScrapList,
   memberData,
 }: ProfileContentProps) {
   switch (selectedOption) {
@@ -23,17 +30,21 @@ export default function ProfileContent({
       return myFeedList ? (
         <MyFeedList feedList={myFeedList} memberData={memberData} />
       ) : (
-        '피드가 없습니다.'
+        <div className={cn('no-post')}>피드가 없습니다.</div>
       );
     case 'post':
       return myPostList ? (
         <MyPostList postList={myPostList} memberData={memberData} />
       ) : (
-        '포스트가 없습니다.'
+        <div className={cn('no-post')}>포스트가 없습니다.</div>
       );
 
     case 'scrap':
-      return <ScrapList />;
+      return myScrapList ? (
+        <MyScrapList scrapList={myScrapList} />
+      ) : (
+        <div className={cn('no-post')}>스크랩 한 게시물이 없습니다.</div>
+      );
     default:
       return null;
   }

--- a/src/pages/post/[postId]/PostDetail.module.scss
+++ b/src/pages/post/[postId]/PostDetail.module.scss
@@ -23,6 +23,7 @@
   height: 56px;
   border-radius: 50%;
   background-color: $glass-02;
+  backdrop-filter: blur(10px);
 
   @include flex-arrange;
   cursor: pointer;

--- a/src/pages/profile/api.ts
+++ b/src/pages/profile/api.ts
@@ -5,6 +5,7 @@ import { FeedDetailType, FeedListType } from '@/components/Feed/types';
 import { PostListDataType, PostListType } from '@/components/Post/types';
 import getMyPostList from '@/components/Profile/MyPostList/api';
 import getMyFeedList from '@/components/Profile/MyFeedList/api';
+import getMyScrapList from '@/components/Profile/MyScrapList/api';
 
 export async function fetchMemberData(
   context: GetServerSidePropsContext,
@@ -12,6 +13,7 @@ export async function fetchMemberData(
   props: {
     myFeedList: FeedDetailType[];
     myPostList: PostListDataType[];
+    myScrapList: PostListDataType[];
     memberData: MemberDataType;
   };
 }> {
@@ -31,11 +33,13 @@ export async function fetchMemberData(
     const memberData: MemberDataType = await res.data;
     const myFeedList: FeedListType = await getMyFeedList(context);
     const myPostList: PostListType = await getMyPostList(context);
+    const myScrapList: PostListType = await getMyScrapList(context);
 
     return {
       props: {
         myFeedList: myFeedList.data,
         myPostList: myPostList.data,
+        myScrapList: myScrapList.data,
         memberData,
       },
     };
@@ -45,6 +49,7 @@ export async function fetchMemberData(
       props: {
         myFeedList: [],
         myPostList: [],
+        myScrapList: [],
         memberData: {
           nickname: '',
           introduce: '',

--- a/src/pages/profile/index.page.tsx
+++ b/src/pages/profile/index.page.tsx
@@ -20,6 +20,7 @@ const cn = classNames.bind(styles);
 export interface MemberDataContainerPropsType {
   myFeedList: FeedListType;
   myPostList: PostListType;
+  myScrapList: PostListType;
   memberData: MemberDataType;
   error?: boolean;
 }
@@ -33,6 +34,7 @@ export default function MemberDataContainer({
   myFeedList,
   myPostList,
   memberData,
+  myScrapList,
   error,
 }: MemberDataContainerPropsType) {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -87,6 +89,7 @@ export default function MemberDataContainer({
       <ContentContainer
         selectedOption={selectedOption}
         setSelectedOption={setSelectedOption}
+        isMyProfile
       >
         <div className={cn('profile-content')}>
           {memberData.authorizationStatus === 'ACCEPT' && (
@@ -94,6 +97,7 @@ export default function MemberDataContainer({
               selectedOption={selectedOption}
               myFeedList={myFeedList}
               myPostList={myPostList}
+              myScrapList={myScrapList}
               memberData={memberData}
             />
           )}

--- a/src/pages/profile/index.page.tsx
+++ b/src/pages/profile/index.page.tsx
@@ -40,6 +40,7 @@ export default function MemberDataContainer({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedOption, setSelectedOption] =
     useState<ContainerOptionType>('feed');
+  const isMine = !memberData.memberId;
 
   // SSR로 가져온 데이터를 쿼리 데이터로 저장 (mutation 후 리패치 위한 작업)
 
@@ -47,9 +48,9 @@ export default function MemberDataContainer({
     queryKey: ['memberData', memberData.memberId], // 사용자 ID 포함시키게 변경
     queryFn: async () => {
       // 이게 어떤 애인지 알아보기
-      const endpoint = memberData.memberId
-        ? `/profile/${memberData.memberId}`
-        : '/profile/mine';
+      const endpoint = isMine
+        ? '/profile/mine'
+        : `/profile/${memberData.memberId}`;
       const res = await instance.get(endpoint, {});
       const fetchedMemberData: MemberDataType = await res.data;
       return fetchedMemberData;
@@ -89,7 +90,7 @@ export default function MemberDataContainer({
       <ContentContainer
         selectedOption={selectedOption}
         setSelectedOption={setSelectedOption}
-        isMyProfile
+        isMyProfile={isMine}
       >
         <div className={cn('profile-content')}>
           {memberData.authorizationStatus === 'ACCEPT' && (


### PR DESCRIPTION

## 📃 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- 

## 💬 무슨 이유로 코드를 변경했는지
- 내 프로필에서 스크랩 한 목록 불러오는 기능 추가했습니다
- 대댓글 수정 버튼 색상 변경 (디자이너님 요청)
- 스크롤 탑 버튼 hover 시 색상 변경 

## ❗ 어떤 위험이나 장애가 발견되었는지
- 

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
- 스크랩 리스트 불러오는건 유정님이 프로필 컴포넌트에서 포스트 불러올 때 하셨던거 고대로 가져와서 적용만했습니다...!
- 댓글 받아올 때 대댓글이 있는지 여부를 나타내는 isReplied 속성을 추가해주셨던데, 어떻게 활용해야할지 잘 모르겠습니다. 
대댓글 여부와 상관없이 답글 달기 버튼으로 대댓글을 확인하거나 남길 수 있도록 하고 있어서 
isReplied 보다는 댓글 데이터에 남겨진 대댓글 갯수를 나타내는 속성이 있으면 더 좋을 것 같습니다!

## ✅ 테스트 계획 또는 완료 사항
-

## 🖼️ 관련 스크린샷

<img width="500" alt="image" src="https://github.com/project-cosmo-sns/cosmos/assets/127701092/bf432fb7-c819-42a6-8e64-d5712192b5f9">

