### PR TITLE
[Feat] 포스트 목록 사전 렌더링

### DIFF
--- a/src/components/Post/PostList/index.tsx
+++ b/src/components/Post/PostList/index.tsx
@@ -8,6 +8,7 @@ import CategoryList from '../CategoryList';
 import { PostListType } from '../types';
 import styles from './PostList.module.scss';
 import PostListContent from './PostListContent';
+import { InfiniteData } from '@tanstack/react-query';
 
 interface PostListProps {
   selectedSort?: SortType;
@@ -25,6 +26,11 @@ export default function PostList({
     ? `&category=${selectedCategory}`
     : '';
 
+  const initialData: InfiniteData<PostListType> = {
+    pages: [initialPostList],
+    pageParams: [1],
+  };
+
   const {
     data: postListData,
     ref,
@@ -39,6 +45,7 @@ export default function PostList({
       }),
     getNextPageParam: (lastPage) =>
       lastPage.meta.hasNextPage ? lastPage.meta.page + 1 : undefined,
+    initialData,
   });
 
   const postDataList = postListData?.pages ?? [];
@@ -55,13 +62,9 @@ export default function PostList({
           setSelectedCategory={setSelectedCategory}
         />
       </div>
-      {isPending ? (
-        <PostListContent postDataList={initialPostList} />
-      ) : (
-        postDataList.map((post) => (
-          <PostListContent key={post.meta.page} postDataList={post} />
-        ))
-      )}
+      {postDataList.map((post) => (
+        <PostListContent key={post.meta.page} postDataList={post} />
+      ))}
       {!isFetchingNextPage && <div ref={ref} />}
     </div>
   );

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -16,6 +16,8 @@ import { FeedListType } from '../components/Feed/types';
 export const getServerSideProps = async (
   context: GetServerSidePropsContext,
 ) => {
+  const initialOption = context.query.tab === 'post' ? 'post' : 'feed';
+
   const feedList = await fetchInitialFeed<FeedListType>(context);
   const postList = await fetchInitialPost<PostListType>(context);
 
@@ -23,6 +25,7 @@ export const getServerSideProps = async (
     props: {
       feedList,
       postList,
+      initialOption,
     },
   };
 };
@@ -30,13 +33,18 @@ export const getServerSideProps = async (
 interface HomePropsType {
   feedList: { props: { response: FeedListType } };
   postList: { props: { response: PostListType } };
+  initialOption: ContainerOptionType;
 }
 
 const cn = classNames.bind(styles);
 
-export default function Home({ feedList, postList }: HomePropsType) {
+export default function Home({
+  feedList,
+  postList,
+  initialOption,
+}: HomePropsType) {
   const [selectedOption, setSelectedOption] =
-    useState<ContainerOptionType>('feed');
+    useState<ContainerOptionType>(initialOption);
   const [selectedSort, setSelectedSort] = useState<SortType>('ALL');
 
   return (


### PR DESCRIPTION

## 💬 무슨 이유로 코드를 변경했는지
- 메인 페이지가 쿼리에 따라 피드와 포스트를 보여주고 있는데, 초기값이 항상 'feed'로 설정되어 있어서 tab쿼리가 post일때도 post 목록은 사전 렌더링이 되지 않고 있어서 initialOption도 getServerSideProps에서 같이 넘겨주도록 수정했습니다..!

## ❗ 어떤 위험이나 장애가 발견되었는지
- 

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  

## ✅ 테스트 계획 또는 완료 사항
-

## 🖼️ 관련 스크린샷
-
