### PR TITLE
[fix] 이미지 업로드 순서 & 파일 등록 순서 동기화 + 재업로드 버그 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next": "14.1.4",
         "next-pwa": "^5.6.0",
         "next-remove-imports": "^1.0.12",
+        "p-limit": "^6.1.0",
         "react": "^18",
         "react-cookie": "^7.1.4",
         "react-dom": "^18",
@@ -8510,6 +8511,35 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.1.0.tgz",
+      "integrity": "sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -8524,14 +8554,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -8804,17 +8831,6 @@
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/yocto-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -11707,12 +11723,11 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.6.8",
         "classnames": "^2.5.1",
         "dom-to-image": "^2.6.0",
+        "dompurify": "^3.1.6",
         "local-ssl-proxy": "^2.0.5",
         "next": "14.1.4",
         "next-pwa": "^5.6.0",
@@ -36,6 +37,7 @@
       },
       "devDependencies": {
         "@types/dom-to-image": "^2.6.7",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^20",
         "@types/react": "^18.2.74",
         "@types/react-dom": "^18",
@@ -2464,6 +2466,15 @@
       "integrity": "sha512-me5VbCv+fcXozblWwG13krNBvuEOm6kA5xoa4RrjDJCNFOZSWR3/QLtOXimBHk1Fisq69Gx3JtOoXtg1N1tijg==",
       "dev": true
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
@@ -4252,6 +4263,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
       "integrity": "sha512-Dt0QdaHmLpjURjU7Tnu3AgYSF2LuOmksSGsUcE6ItvJoCWTBEmiMXcqBdNSAm9+QbbwD7JMoVsuuKX6ZVQv1qA=="
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.6.8",
     "classnames": "^2.5.1",
     "dom-to-image": "^2.6.0",
+    "dompurify": "^3.1.6",
     "local-ssl-proxy": "^2.0.5",
     "next": "14.1.4",
     "next-pwa": "^5.6.0",
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "@types/dom-to-image": "^2.6.7",
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^20",
     "@types/react": "^18.2.74",
     "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "14.1.4",
     "next-pwa": "^5.6.0",
     "next-remove-imports": "^1.0.12",
+    "p-limit": "^6.1.0",
     "react": "^18",
     "react-cookie": "^7.1.4",
     "react-dom": "^18",

--- a/src/components/Common/Layout/Modal/index.tsx
+++ b/src/components/Common/Layout/Modal/index.tsx
@@ -70,7 +70,7 @@ export default function Modal({
               onClick={handleXIconClick}
             />
             <div className={cn(cssModalSize)} ref={modalRef}>
-              <div className={cn('wrapper', border && 'border')}>
+              <div className={cn('wrapper', { border })}>
                 {title && (
                   <div className={cn('title')}>
                     <span>{title}</span>

--- a/src/components/Feed/CreateFeed/CreateFeed.module.scss
+++ b/src/components/Feed/CreateFeed/CreateFeed.module.scss
@@ -42,6 +42,7 @@
         border-radius: 5px;
         resize: none;
         white-space: pre-wrap;
+        border: 0.1px solid transparent;
       }
 
       .error {
@@ -53,6 +54,10 @@
         padding-left: 16px;
       }
 
+      .error-border {
+        border: 0.1px solid #ed1c24;
+      }
+
       .limit {
         position: absolute;
         right: 16px;
@@ -60,6 +65,10 @@
         font-size: 1.1rem;
         color: $gray-01;
         padding-left: 16px;
+      }
+
+      .warn {
+        color: #b5141a;
       }
 
       .addImage {

--- a/src/components/Feed/CreateFeed/index.tsx
+++ b/src/components/Feed/CreateFeed/index.tsx
@@ -135,7 +135,7 @@ export default function CreateFeed({
         />
         <div className={cn('content')}>
           <textarea
-            className={cn('text', errors.content && 'error-border')}
+            className={cn('text', { 'error-border': errors.content })}
             rows={5}
             maxLength={350}
             placeholder="글을 작성해주세요"
@@ -161,7 +161,7 @@ export default function CreateFeed({
             </span>
           )}
           <span
-            className={cn('limit', watch('content').length > 300 && 'warn')}
+            className={cn('limit', { warn: watch('content').length > 300 })}
           >
             {watch('content') && watch('content').length}/300
           </span>

--- a/src/components/Feed/CreateFeed/index.tsx
+++ b/src/components/Feed/CreateFeed/index.tsx
@@ -129,15 +129,23 @@ export default function CreateFeed({
         />
         <div className={cn('content')}>
           <textarea
-            className={cn('text')}
+            className={cn('text', errors.content && 'error-border')}
             rows={5}
-            maxLength={300}
+            maxLength={350}
             placeholder="글을 작성해주세요"
             {...register('content', {
               required: '게시글을 작성해주세요',
-              maxLength: 300,
+              minLength: {
+                value: 1,
+                message: '게시글을 작성해 주세요.',
+              },
+              maxLength: {
+                value: 300,
+                message: '최대 300자 까지 작성 가능합니다.',
+              },
               validate: {
-                whiteSpace: (value) => !!value.trim() || '댓글을 입력해주세요',
+                whiteSpace: (value) =>
+                  !!value.trim() || '게시글을 작성 해주세요.',
               },
             })}
           />
@@ -146,7 +154,9 @@ export default function CreateFeed({
               {errors.content.message?.toString()}
             </span>
           )}
-          <span className={cn('limit')}>
+          <span
+            className={cn('limit', watch('content').length > 300 && 'warn')}
+          >
             {watch('content') && watch('content').length}/300
           </span>
           <div className={cn('addImage')}>

--- a/src/components/Feed/CreateFeed/index.tsx
+++ b/src/components/Feed/CreateFeed/index.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import classNames from 'classnames/bind';
 import { useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
+import DOMPurify from 'dompurify';
 import axios from 'axios';
 import DefaultButton from '@/components/Common/Buttons/DefaultButton';
 import { AddImageIcon, CloseIcon } from '@/components/Common/IconCollection';
@@ -103,7 +104,12 @@ export default function CreateFeed({
   };
 
   const onSubmit = async (data: FeedType) => {
-    postFeed(data);
+    const sanitizedContent = DOMPurify.sanitize(data.content);
+    const sanitizedData = {
+      content: sanitizedContent,
+      feedImage: data.feedImage,
+    };
+    postFeed(sanitizedData);
   };
 
   const imagePreview = updateImageUrls();

--- a/src/components/Feed/FeedCard/FeedCard.module.scss
+++ b/src/components/Feed/FeedCard/FeedCard.module.scss
@@ -1,4 +1,4 @@
-.padding {
+.FeedCardPadding {
   padding: 16px;
 }
 

--- a/src/components/Feed/FeedCard/index.tsx
+++ b/src/components/Feed/FeedCard/index.tsx
@@ -92,8 +92,6 @@ export default function FeedCard({
       isPost: false,
     });
 
-  console.log(imageUrls, '---test-three---');
-
   return (
     <div
       className={cn(

--- a/src/components/Feed/FeedCard/index.tsx
+++ b/src/components/Feed/FeedCard/index.tsx
@@ -96,8 +96,9 @@ export default function FeedCard({
     <div
       className={cn(
         'container',
-        hasPadding && 'padding',
-        forDetails || 'container-hover',
+        // eslint-disable-next-line prettier/prettier
+        { FeedCardPadding: hasPadding },
+        { 'container-hover': !forDetails },
       )}
     >
       <div className={cn('wrapper')}>
@@ -138,10 +139,10 @@ export default function FeedCard({
                       blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
                       fill
                       onLoad={() => setImageLoading(false)}
-                      className={cn(
-                        'image-item',
-                        isImageLoading ? 'blur' : 'remove-blur',
-                      )}
+                      className={cn('image-item', {
+                        blur: isImageLoading,
+                        'remove-blur': !isImageLoading,
+                      })}
                       style={{ objectFit: 'cover' }}
                       src={url}
                       sizes="33vw"
@@ -153,7 +154,7 @@ export default function FeedCard({
                 ))}
               </div>
             )}
-            <div className={cn('content', forDetails || 'content-hidden')}>
+            <div className={cn('content', { 'content-hidden': forDetails })}>
               <TextWithLinks text={content} />
             </div>
           </div>

--- a/src/components/Feed/FeedCard/index.tsx
+++ b/src/components/Feed/FeedCard/index.tsx
@@ -92,6 +92,8 @@ export default function FeedCard({
       isPost: false,
     });
 
+  console.log(imageUrls, '---test-three---');
+
   return (
     <div
       className={cn(

--- a/src/components/Feed/FeedCard/index.tsx
+++ b/src/components/Feed/FeedCard/index.tsx
@@ -96,7 +96,6 @@ export default function FeedCard({
     <div
       className={cn(
         'container',
-        // eslint-disable-next-line prettier/prettier
         { FeedCardPadding: hasPadding },
         { 'container-hover': !forDetails },
       )}
@@ -154,7 +153,7 @@ export default function FeedCard({
                 ))}
               </div>
             )}
-            <div className={cn('content', { 'content-hidden': forDetails })}>
+            <div className={cn('content', { 'content-hidden': !forDetails })}>
               <TextWithLinks text={content} />
             </div>
           </div>


### PR DESCRIPTION
## 💬 무슨 이유로 코드를 변경했는지
- 인풋 이미지 업로드 순서와 s3 폼 제출 이미지 순서가 서로 달라 데이터를 불러올 때, 순서가 보장되지 않음

- 여러번에 걸쳐 삭제 후, 업로드 시 사진이 서로 꼬이는 현상 

## ❗ 어떤 위험이나 장애가 발견되었는지
- 순서에 맞게 봐야하는 이미지를 사용자가 업로드 했을 시, 이상하게 동작하게 된다면 서비스 품질이 떨어지므로 수정함.

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
- 이슈에 글 작성 해놓았습니다. 시간나시면 한번 씩 봐주세염 
-  #210
- #211 

## ✅ 테스트 계획 또는 완료 사항
-

## 🖼️ 관련 스크린샷
-
