### PR TITLE
[Fix] 탭 클릭시 쿼리키 유실 현상으로 인한 쿼리 프로바이더 수정

### DIFF
--- a/src/components/Feed/CreateFeed/index.tsx
+++ b/src/components/Feed/CreateFeed/index.tsx
@@ -20,10 +20,7 @@ import { useToast } from '@/hooks/useToast';
  * @return {JSX.Element} 글작성 인풋과 이미지 추가하는 인풋을 포함하는 CreatedFeed 컴포넌트 입니다.
  */
 
-export default function CreateFeed({
-  profileImage,
-  modalVisible,
-}: CreatedFeedTypes) {
+export default function CreateFeed({ profileImage }: CreatedFeedTypes) {
   const cn = classNames.bind(styles);
   const {
     register,
@@ -72,8 +69,7 @@ export default function CreateFeed({
 
   // 이미지 업로드 함수
   const uploadFile = async (fileList: Blob[]) => {
-    const currentImageValue =
-      images.length === 0 ? fileList : [...images, ...fileList];
+    const currentImageValue = [...images, ...fileList];
     setImages(currentImageValue);
     const limit = pLimit(1);
 

--- a/src/components/Feed/FeedList/index.tsx
+++ b/src/components/Feed/FeedList/index.tsx
@@ -27,9 +27,8 @@ const cn = classNames.bind(styles);
 
 export default function FeedList({ feedList, selectedSort }: FeedListProps) {
   const { checkMemberStatus } = useFetchMemberStatus();
-  const [selectedCategory, setSelectedCategory] = useState<string>('ALL');
-  const queryParam = CATEGORY_LIST[selectedCategory]
-    ? `&category=${selectedCategory}`
+  const queryParam = CATEGORY_LIST[selectedSort]
+    ? `&category=${selectedSort}`
     : '';
   const [feedId, setFeedId] = useState<number>(0);
   const dispatch = useDispatch();
@@ -72,12 +71,12 @@ export default function FeedList({ feedList, selectedSort }: FeedListProps) {
 
   useEffect(() => {
     refetch();
-  }, [selectedCategory, selectedSort]);
+  }, [selectedSort]);
 
   return (
     <div className={cn('wrapper')}>
       <div className={cn('container')}>
-        {feedPages[0].data.length ? (
+        {feedPages.length ? (
           feedPages.map((feedPage) =>
             feedPage.data.map((feed) => (
               <FeedCard

--- a/src/utils/QueryProvider.tsx
+++ b/src/utils/QueryProvider.tsx
@@ -7,16 +7,19 @@ type Props = {
 };
 
 function QueryProvider({ children }: Props) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-        retry: false,
-        retryDelay: 3000,
-      },
-    },
-  });
+  const [queryClient] = React.useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
+            retry: false,
+            retryDelay: 3000,
+          },
+        },
+      }),
+  );
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## 📃 관련 이슈
#204 

## 💬 무슨 이유로 코드를 변경했는지
- 라우팅 시 쿼리 키 유실 오류

## ❗ 어떤 위험이나 장애가 발견되었는지
- 피드 생성, 삭제 후에 invalidate 되지 못해 새로운 데이터를 불러오지 못함 

## 👀 어떤 부분에 리뷰어가 집중하면 좋을지
-  쿼리 클라이언트의 재 실행

## 발생한 버그
- 피드작성 -> 성공 -> 쿼리키를 활용한 피드 리스트 invalidate -> 최신 데이터 출력 
- 위의 동작이 기대하는 순서입니다. 하지만 cosmos 로고 클릭후 또는 tab 클릭시 쿼리키를 잃어버려 invalidate 하지 못하는 현상을 발견하였습니다. 

## 수정 내용

- 탭 클릭 활용한 라우팅 시 App 컴포넌트가 리렌더링 되면서 App 컴포넌트 내부에서 생성되는 쿼리 클라이언트가 다시 생성 실행됨.

- 다시 실행되는 과정에서 쿼리 키를 모두 잃어버림 

- useState 와 the lazy initializer 로 App 컴포넌트가 리렌더링 되더라도 쿼리 클라이언트가 다시 실행되지 않게 함 

📎 [라우팅시 쿼리키가 사라지는 이유](https://velog.io/@yunsunglee2/%ED%83%AD-%ED%81%B4%EB%A6%AD%EC%8B%9C-%EC%BF%BC%EB%A6%AC%ED%82%A4%EA%B0%80-%EC%82%AC%EB%9D%BC%EC%A7%80%EB%8A%94-%ED%98%84%EC%83%81)
